### PR TITLE
Fix unfinished string in frFR localization

### DIFF
--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -230,7 +230,7 @@ L["LootUI Option Replace Default Tooltip"] = "Remplace les alertes de butin par 
 L["LootUI Option Loot Under Mouse"] = LOOT_UNDER_MOUSE_TEXT or "Ouvrir la fenêtre de butin à la souris";
 L["LootUI Option Loot Under Mouse Tooltip"] = "En mode |cffffffffButin manuel|r, la fenêtre apparaîtra sous la position actuelle de la souris";
 L["LootUI Option Use Default UI"] = "Utiliser la fenêtre de butin par défaut";
-L["LootUI Option Use Default UI Tooltip"] = "Utiliser la fenêtre de butin par défaut de WoW.\n\n|cffff4800Activer cette option annule tous les réglage
+L["LootUI Option Use Default UI Tooltip"] = "Utiliser la fenêtre de butin par défaut de WoW.\n\n|cffff4800Activer cette option annule tous les réglage";
 
 
 --Generic


### PR DESCRIPTION
Regression after https://github.com/Peterodox/Plumber/pull/25/files#diff-04b28052ac6102dd854c473e36541fb419e4bb0bf7ed3a97c58363bd51b6326fR228

Fixes Lua errors in game:
```
2x Plumber/Locales/frFR.lua:233: unfinished string near '"Utiliser la fenêtre de butin par défaut de WoW.

Activer cette option annule tous les réglage'


Locals:
```
```
4x Plumber/Locales/frFR.lua:1 Plumber/Locales/frFR.lua:233: unfinished string near '"Utiliser la fenêtre de butin par défaut de WoW.

Activer cette option annule tous les réglage'
```