### PR TITLE
Fix for FADE_DELAY_PER_ITEM not setting on login

### DIFF
--- a/Modules/LootUI_Display.lua
+++ b/Modules/LootUI_Display.lua
@@ -1754,7 +1754,7 @@ do  --Edit Mode
     addon.CallbackRegistry:RegisterSettingCallback("LootUI_ShowItemCount", SettingChanged_ShowItemCount);
 
     local function SettingChanged_FadeDelayPerItem(value, userInput)
-        AUTO_HIDE_DELAY = GetValidFadeOutDelay(value);
+        FADE_DELAY_PER_ITEM = GetValidFadeOutDelay(value);
     end
     addon.CallbackRegistry:RegisterSettingCallback("LootUI_FadeDelayPerItem", SettingChanged_FadeDelayPerItem);
 


### PR DESCRIPTION
Hi,

I found an oversight in how `FADE_DELAY_PER_ITEM` is set on login.
Since `AUTO_HIDE_DELAY` is calculated based on `FADE_DELAY_PER_ITEM`, I believe this is the correct assignment.

It also seems to work correctly in practice.

Thanks for your great addon! 👍
