### PR TITLE
Added the Phase Diver's Cache to the major weekly caches list

### DIFF
--- a/Modules/SharedData.lua
+++ b/Modules/SharedData.lua
@@ -41,6 +41,7 @@ do  --Weekly Caches (Meta quest rewards)
             244842,     --Fabled Veteran's Cache
             244865,     --Pninnacle Cache
             245611,     --Wriggling Pinnacle Cache
+            255676,     --Phase Diver's Cache
         },
 
         MinorChests = {


### PR DESCRIPTION
The Phase Diver's Cache (item id: 255676, reward from the weekly More Than Just a Phase quest) was missing from the list of major weekly caches that reward a complete coffer key, so I added it.