### PR TITLE
Update LandingPageSwitch to include Reshii Wraps pane

### DIFF
--- a/Modules/LandingPageSwitch.lua
+++ b/Modules/LandingPageSwitch.lua
@@ -140,6 +140,14 @@ local ButtonMenu = {
 
         --{type = "Button", name = DRAGONFLIGHT_LANDING_PAGE_TITLE, OnClick = function() ELPOverride.OpenExpansionLandingPage(LE_EXPANSION_DRAGONFLIGHT) end},
         --{type = "Button", name = WAR_WITHIN_LANDING_PAGE_TITLE, OnClick = function() ELPOverride.OpenExpansionLandingPage(LE_EXPANSION_WAR_WITHIN) end},
+        {type = "Button", name = "Reshii Wraps",
+            OnClick = function()
+                GenericTraitUI_LoadUI();
+                GenericTraitFrame:SetSystemID(29);
+                GenericTraitFrame:SetTreeID(1115);
+                ToggleFrame(GenericTraitFrame);
+            end
+        },
     },
 };
 


### PR DESCRIPTION
I always find the need to be able to open the auxiliary panes for some reason or another. I felt that it fit nicely in the Landing Page Module.

I moved the common macro code into the on click.

If this is not the right place, or there is more work that is needed, let me know.