### PR TITLE
Fix 'Show' on bad self error for embedded tooltips

### DIFF
--- a/Modules/GameTooltip_Core.lua
+++ b/Modules/GameTooltip_Core.lua
@@ -127,8 +127,8 @@ do
 			end
 		end
 
-		if self.anyChange and tooltip == GameTooltip then
-			tooltip:Show();
+		if self.anyChange then
+			pcall(tooltip.Show, tooltip);
 		end
 
 		if self.hasAltMode then


### PR DESCRIPTION
## Summary

Fixes `calling 'Show' on bad self (Usage: self:Show())` errors that happen when hovering PvP reward items (or anything using `EmbeddedItemTooltipTooltip`).

`CallSubModules` fires for all tooltip frames that inherit `GameTooltipTemplate`, but `tooltip:Show()` doesn't work on embedded tooltip frames. This just guards the call so it only runs on `GameTooltip`.

One-line change in `Modules/GameTooltip_Core.lua`.