### PR TITLE
Account for faction when checking mount usability

### DIFF
--- a/Modules/Macros.lua
+++ b/Modules/Macros.lua
@@ -1126,10 +1126,11 @@ do  --MacroInterpreter
 						macroText = "/run C_MountJournal.SummonByID(0)";
 						id = _spellID;
 					else
-						local  _name, _spellID, _icon, _isActive, _isUsable, _sourceType, _isFavorite, _isFactionSpecific, _faction, _shouldHideOnChar, _isCollected = GetMountInfoByID(id);
+						local factionIndex = API.GetPlayerFactionIndex();
+						local _name, _spellID, _icon, _isActive, _isUsable, _sourceType, _isFavorite, _isFactionSpecific, _faction, _shouldHideOnChar, _isCollected = GetMountInfoByID(id);
 						name = GetSpellName(_spellID) or _name;
 						icon = _icon;
-						usable = _isCollected;
+						usable = _isCollected and (_faction == nil or _faction == factionIndex);
 						macroText = format("/run C_MountJournal.SummonByID(%d)", id);
 						id = _spellID;
 					end


### PR DESCRIPTION
fixes #402 

Updates the usable check so faction specific mounts are also checked if valid.