### PR TITLE
fix: Update mount usability check logic

### DIFF
--- a/Modules/Macros.lua
+++ b/Modules/Macros.lua
@@ -1162,11 +1162,10 @@ do  --MacroInterpreter
 						macroText = "/run C_MountJournal.SummonByID(0)";
 						id = _spellID;
 					else
-						local factionIndex = API.GetPlayerFactionIndex();
 						local _name, _spellID, _icon, _isActive, _isUsable, _sourceType, _isFavorite, _isFactionSpecific, _faction, _shouldHideOnChar, _isCollected = GetMountInfoByID(id);
 						name = GetSpellName(_spellID) or _name;
 						icon = _icon;
-						usable = _isCollected and (_faction == nil or _faction == factionIndex);
+						usable = _isCollected and not _shouldHideOnChar;
 						macroText = format("/run C_MountJournal.SummonByID(%d)", id);
 						id = _spellID;
 					end


### PR DESCRIPTION
This fixes a regression added in #403 

GetMountInfoById returns 0 or 1, for Horde and Alliance, but the GetPlayerFactionIndex function returns 1 or 2 for alliance and horde.

To avoid changing everything using `shouldHideOnChar` should help here instead. 

context: https://wowpedia.fandom.com/wiki/API_C_MountJournal.GetMountInfoByID#:~:text=10%2E-,shouldHideOnChar