### PR TITLE
1.9.1 d

### DIFF
--- a/Initialization.lua
+++ b/Initialization.lua
@@ -1,5 +1,5 @@
-local VERSION_TEXT = "1.9.1 c";
-local VERSION_DATE = 1777200000;
+local VERSION_TEXT = "1.9.1 d";
+local VERSION_DATE = 1777500000;
 
 
 local addonName, addon = ...

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -764,6 +764,9 @@ L["Instruction Alt Click To Reset Instance"] = "Alt Right-Click: |cffffffffReset
 L["Instruction Link Progress In Chat"] = "<Shift click to post progress in chat>";
 L["Instance Name"] = "Instance Name";   --Dungeon/Raid Name
 L["EditMode Instruction InstanceDifficulty"] = "The frame width is affected by the number of available options.";
+L["Difficulty Locked To Format"] = "The instance is locked to |cffffffff%s|r due to boss kill.";
+L["Difficulty Locked To Current Alert"] = "The instance is locked to this difficulty due to boss kill.";
+L["Shared Difficulty Alert"] = "Defeating a boss will lock the instance to this difficulty.";
 
 
 --TransmogChatCommand

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -733,6 +733,9 @@ L["Instruction Alt Click To Reset Instance"] = "按住Alt并右键单击：|cfff
 L["Instruction Link Progress In Chat"] = "<按住Shift点击将副本进度链接到聊天框内>";
 L["Instance Name"] = "副本名称";
 L["EditMode Instruction InstanceDifficulty"] = "此窗口的实际宽度由选项数量决定。";
+L["Difficulty Locked To Format"] = "此副本难度被锁定为|cffffffff%s|r，因为你已击败了一个首领。";
+L["Difficulty Locked To Current Alert"] = "此副本难度被锁定为当前难度，因为你已击败了一个首领。";
+L["Shared Difficulty Alert"] = "击败任何一个首领将会使副本锁定至此难度。";
 
 
 --TransmogChatCommand

--- a/Modules/BlizzFix_EndCaps.lua
+++ b/Modules/BlizzFix_EndCaps.lua
@@ -44,7 +44,7 @@ do
 		dbKey = "BlizzFixActionBarArt",
 		description = addon.L["ModuleDescription BlizzFixActionBarArt"],
 		toggleFunc = EnableModule,
-		moduleAddedTime = 1755200000,
+		moduleAddedTime = 1777500000,
 		categoryKeys = {
 			"Housing",
 		},

--- a/Modules/BlizzFix_EndCaps.lua
+++ b/Modules/BlizzFix_EndCaps.lua
@@ -9,6 +9,11 @@ local function TempFix_RestoreActionBarEndCaps()
 	MainActionBar.EndCaps:SetShown(MainActionBar.BorderArt:IsShown());
 end
 
+local function OnEvent()
+	-- Just one UPDATE_OVERRIDE_ACTIONBAR
+	TempFix_RestoreActionBarEndCaps();
+end
+
 local function EnableModule(state)
 	if state then
 		if not UIParentTracker then
@@ -19,12 +24,16 @@ local function EnableModule(state)
 					TempFix_RestoreActionBarEndCaps();
 				end
 			end);
+
+			UIParentTracker:SetScript("OnEvent", OnEvent);
 		end
 		UIParentTracker.enabled = true;
+		UIParentTracker:RegisterEvent("UPDATE_OVERRIDE_ACTIONBAR");
 		TempFix_RestoreActionBarEndCaps();
 	else
 		if UIParentTracker then
 			UIParentTracker.enabled = false;
+			UIParentTracker:UnregisterEvent("UPDATE_OVERRIDE_ACTIONBAR");
 		end
 	end
 end

--- a/Modules/ControlCenter/Changelog/enUS.lua
+++ b/Modules/ControlCenter/Changelog/enUS.lua
@@ -11,14 +11,26 @@ local changelogs = addon.ControlCenter.changelogs;
 changelogs[10901] = {
 	{
 		type = "date",
-		versionText = "1.9.1 b-c",
-		timestamp = 1777200000,
+		versionText = "1.9.1 b-d",
+		timestamp = 1777500000,
 	},
 
 	{
 		type = "p",
 		bullet = true,
-		text = "Action Bar Art: Added a new module to fix the issue where the Action Bar Art (gryphons and wyverns) reappears unexpectedly after Hiding/Showing UI or exiting House Editor.",
+		text = "Instance Difficulty Selector: The lockout tooltip will inform you if the difficulty cannot be changed due to a boss being defeated. Note: Applies only to pre-Siege of Orgrimmar raids.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Queue Status: It now works on queues that have no estimated wait time.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Action Bar Art: Added a new module to fix the issue where the Action Bar Art (gryphons and wyverns) reappears unexpectedly after Hiding/Showing UI or exiting House Editor or vehicles.",
 	},
 
 	{

--- a/Modules/DevTool.lua
+++ b/Modules/DevTool.lua
@@ -407,6 +407,7 @@ if true then    --Secret Debug
 
 	local CVars = {
 		"ChallengeMode",
+		"Chat",
 		"Combat",
 		"Encounter",
 		"Map",
@@ -414,7 +415,7 @@ if true then    --Secret Debug
 	};
 
 	for _, v in ipairs(CVars) do
-		C_CVar.SetCVar("secret"..v.."RestrictionsForced", value);
+		C_CVar.SetCVar("addon"..v.."RestrictionsForced", value);
 	end
 end
 

--- a/Modules/QueueStatus.lua
+++ b/Modules/QueueStatus.lua
@@ -262,7 +262,11 @@ do
 				--print(tankNeeds, healerNeeds, dpsNeeds);
 				--print(totalTanks, totalHealers, totalDPS);
 				--print(averageWait, myWait, queuedTime);
-				if averageWait > 0 then
+				if averageWait then
+					-- Dungeon Queues in Chromie Time show no Estimated Queue Time (averageWait = -1)
+					averageWait = averageWait < 0 and 0 or averageWait;
+					myWait = myWait < 0 and 0 or myWait;
+
 					local total = totalTanks + totalHealers + totalDPS;
 					if total <= 1 then
 						percentage = 1;

--- a/Modules/RaidCheck/DifficultySelector.lua
+++ b/Modules/RaidCheck/DifficultySelector.lua
@@ -92,6 +92,8 @@ local function ShowLockoutTooltip(self, instanceName, difficultyName, instanceID
 	tooltip:AddDoubleLine(instanceName, difficultyName);
 	tooltip:SetCustomLineSpacing(4);
 
+	local currentDifficultyID = self.encounters[1].difficultyID;
+
 	for i, v in ipairs(self.encounters) do
 		local hasDefeated = v.dungeonEncounterID and IsEncounterComplete(instanceID, v.dungeonEncounterID, v.difficultyID);
 		if i % 5 == 1 then
@@ -110,9 +112,22 @@ local function ShowLockoutTooltip(self, instanceName, difficultyName, instanceID
 			tooltip:AddLine(L["Cannot Change Difficulty"], 1, 0.125, 0.125, true);
 		end
 
-		if SelectorUI.isRaid and API.HasActiveChatBox() and SelectorUI:CanLinkProgress(self.encounters[1].difficultyID) then
+		if SelectorUI.isRaid and API.HasActiveChatBox() and SelectorUI:CanLinkProgress(currentDifficultyID) then
 			tooltip:AddLine(" ");
 			tooltip:AddLine(L["Instruction Link Progress In Chat"], 0.098, 1.000, 0.098, true);
+		end
+	end
+
+	if SelectorUI.isSharedLockout then
+		tooltip:AddLine(" ");
+		if SelectorUI.lockedDifficultyID then
+			if SelectorUI.lockedDifficultyID == currentDifficultyID then
+				tooltip:AddLine(L["Difficulty Locked To Current Alert"], 1, 0.82, 0, true);
+			else
+				tooltip:AddLine(L["Difficulty Locked To Format"]:format(API.GetRaidDifficultyString(SelectorUI.lockedDifficultyID)), 1, 0.125, 0.125, true);
+			end
+		else
+			tooltip:AddLine(L["Shared Difficulty Alert"], 1, 0.82, 0, true);
 		end
 	end
 
@@ -597,6 +612,7 @@ do  --SelectorUI
 		if event == "PLAYER_DIFFICULTY_CHANGED" then
 			self:UpdateDifficulty(true);
 		elseif event == "UPDATE_INSTANCE_INFO" then
+			self:UpdateLockedDifficultyID();
 			self:UpdateInstanceProgress();
 		elseif event == "GROUP_ROSTER_UPDATE" or event == "PARTY_LEADER_CHANGED" then
 			self:RequestUpdate();
@@ -708,7 +724,9 @@ do  --SelectorUI
 				end
 
 				self.isLegacyRaid = instanceInfo.isLegacyRaid;
+				self.isSharedLockout = self.isLegacyRaid and IsLegacyDifficulty(self.fallbackDifficultyID);
 
+				self:UpdateLockedDifficultyID();
 				self:UpdateDifficulty(false);
 				self.hasInstanceData = true;
 			else
@@ -867,6 +885,31 @@ do  --SelectorUI
 		local index = self:GetSavedInstanceIndex(difficultyID);
 		if index then
 			return API.ChatInsertLink(GetSavedInstanceChatLink(index));  --Dungeon progress sent as plain text for some reason?
+		end
+	end
+
+	function SelectorUI:UpdateLockedDifficultyID()
+		-- For legacy raids pre SoO
+
+		self.difficultyID = nil;
+
+		if self.isSharedLockout and self.isValidDifficulty then
+			for difficultyID in pairs(self.isValidDifficulty) do
+				local encounters = GetInstanceEncounters(self.journalInstanceID, difficultyID);
+				local anyComplete;
+				if encounters then
+					for _, v in ipairs(encounters) do
+						if v.dungeonEncounterID and IsEncounterComplete(self.instanceID, v.dungeonEncounterID, difficultyID) then
+							self.lockedDifficultyID = difficultyID;
+							anyComplete = true;
+							break;
+						end
+					end
+				end
+				if anyComplete then
+					--print("Active Lockout on:", API.GetRaidDifficultyString(difficultyID));
+				end
+			end
 		end
 	end
 end


### PR DESCRIPTION
- **Instance Difficulty Selector:** The lockout tooltip will inform you if the difficulty cannot be changed due to a boss being defeated. Note: Applies only to pre-Siege of Orgrimmar raids. #419 
- **Queue Status:** It now works on queues that have no estimated wait time. #422 
- **Action Bar Art Fix:** It should correctly apply the fix when the main action bar is overridden by vehicles.