### PR TITLE
1.9.2 b

### DIFF
--- a/Initialization.lua
+++ b/Initialization.lua
@@ -1,5 +1,5 @@
-local VERSION_TEXT = "1.9.2";
-local VERSION_DATE = 1778200000;
+local VERSION_TEXT = "1.9.2 b";
+local VERSION_DATE = 1778800000;
 
 
 local addonName, addon = ...

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -235,40 +235,40 @@ L["Seed Color Uncommon"] = ICON_TAG_RAID_TARGET_TRIANGLE3 or "Green";
 
 
 --Tooltip Chest Keys
-L["ModuleName TooltipChestKeys"] = "Chest Keys";
+L["ModuleName TooltipChestKeys"] = "Tooltip: Chest Keys";
 L["ModuleDescription TooltipChestKeys"] = "Show info on the key required to open the current chest or door.";
 
 
 --Tooltip Reputation Tokens
-L["ModuleName TooltipRepTokens"] = "Reputation Tokens";
+L["ModuleName TooltipRepTokens"] = "Tooltip: Reputation Tokens";
 L["ModuleDescription TooltipRepTokens"] = "Show the faction info if the item can be used to increase reputation.";
 
 
 --Tooltip Mount Recolor
-L["ModuleName TooltipSnapdragonTreats"] = "Snapdragon Treats";
+L["ModuleName TooltipSnapdragonTreats"] = "Tooltip: Snapdragon Treats";
 L["ModuleDescription TooltipSnapdragonTreats"] = "Show additional info for Snapdragon Treats.";
 L["Color Applied"] = "This is the currently applied color.";
 
 
 --Tooltip Item Reagents
-L["ModuleName TooltipItemReagents"] = "Reagents";
+L["ModuleName TooltipItemReagents"] = "Tooltip: Reagents";
 L["ModuleDescription TooltipItemReagents"] = "If an item can be used to combine into something new, display all \"reagents\" used in the process.\n\nPress and hold Shift to display the crafted item if supported.";
 L["Can Create Multiple Item Format"] = "You have the resources to create |cffffffff%d|r items.";
 
 
 --Tooltip DelvesItem
-L["ModuleName TooltipDelvesItem"] = "Delves Items";
+L["ModuleName TooltipDelvesItem"] = "Tooltip: Delves Items";
 L["ModuleDescription TooltipDelvesItem"] = "Show how many Coffer Keys and Shards you have earned from weekly caches.";
 L["You Have Received Weekly Item Format"] = "You have received %s this week.";
 
 
 --Tooltip ItemQuest
-L["ModuleName TooltipItemQuest"] = "Quest Starting Items";
+L["ModuleName TooltipItemQuest"] = "Tooltip: Quest Starting Items";
 L["ModuleDescription TooltipItemQuest"] = "If an item in your bag starts a quest, show the quest details.\n\nYou can Ctrl Left Click the item to view it in the quest log if you are already on the quest.";
 L["Instruction Show In Quest Log"] = "<Ctrl Click to View in Quest Log>";
 
 
-L["ModuleName TooltipTransmogEnsemble"] = "Transmog Ensembles";
+L["ModuleName TooltipTransmogEnsemble"] = "Tooltip: Transmog Ensembles";
 L["ModuleDescription TooltipTransmogEnsemble"] = "- Show the number of collectable appearances from an Ensemble.\n\n- Fixed the issue where the tooltip says \"Already known\" but you can still use it to unlock new appearances.";
 L["Collected Appearances"] = "Collected Appearances";
 L["Collected Items"] = "Collected Items";
@@ -290,7 +290,7 @@ L["No Resilient Seed"] = "No Resilient Seeds";
 
 
 --Tooltip VendorLocation
-L["ModuleName TooltipVendorLocation"] = "Vendor Locations";
+L["ModuleName TooltipVendorLocation"] = "Tooltip: Vendor Locations";
 L["ModuleDescription TooltipVendorLocation"] = "Show where to exchange certain tokens on the item tooltip and allow Ctrl-Clicking the item to set a map pin to the vendor.";
 L["Instruction Set Waypoint"] = "<Ctrl click to set a map pin>";
 L["NPC Name Location Format"] = "%s, %s";

--- a/Modules/ControlCenter/Changelog/enUS.lua
+++ b/Modules/ControlCenter/Changelog/enUS.lua
@@ -11,6 +11,73 @@ local changelogs = addon.ControlCenter.changelogs;
 changelogs[10902] = {
 	{
 		type = "date",
+		versionText = "1.9.2 b",
+		timestamp = 1778800000,
+	},
+
+	{
+		type = "h1",
+		text = "Bug Fixes",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "House Macros: Fixed an error that occurred during the initial login.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Loot Window: The \"Take All\" hotkey indicator (Default: E) now automatically hides when entering combat, meaning the hotkey is disabled due to combat restrictions.",
+	},
+	{
+		type = "p",
+		bullet = 2,
+		text = "Note: Hotkeys bound to a single modifier key (SHIFT, CTRL, or ALT) remain functional regardless of combat status.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Tooltip Reagents: Corrected the required quantity display for Ascendant Voidcore (updated from 4 to 5).",
+	},
+	{
+		type = "p",
+		bullet = 2,
+		text = "Note: We are aware that some reagent counts may still be off by 1; these are being patched manually as they are identified.",
+	},
+
+	{
+		type = "br",
+	},
+
+	{
+		type = "h1",
+		text = "Added",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Expansion Summary UI: Added Nebulous Voidcore (bonus rolls) to the resource list.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Text Outline: Implemented Slug text rendering for certain Plumber fonts, which improves legibility and sharpness when text is displayed at smaller scales.",
+	},
+
+	{
+		type = "br",
+	},
+	{
+		type = "br",
+	},
+
+	{
+		type = "date",
 		versionText = "1.9.2",
 		timestamp = 1778200000,
 	},

--- a/Modules/ControlCenter/SettingsPanelNew.lua
+++ b/Modules/ControlCenter/SettingsPanelNew.lua
@@ -24,7 +24,8 @@ local Def = {
 	ChangelogLineSpacing = 4,
 	ChangelogParagraphSpacing = 16,
 	ChangelogLineBreakHeight = 32,
-	ChangelogIndent = 16,   --22 to match Checkbox Label
+	ChangelogIndent = 16,   -- 22 to match Checkbox Label. Equal to a "- " in markdown
+	ChangelogIndent2 = 32,	-- Equal to a "  - " in markdown
 	ChangelogImageSize = 240,
 	ChangelogImageSizeLarge = 300,
 
@@ -1652,6 +1653,8 @@ do  --ChangelogTab
 				end
 			end
 
+			local extraLeftOffset = 0;
+
 			if info.type == "h1" or info.type == "p" then
 				local text = info.text;
 				if info.isNewFeature then
@@ -1659,7 +1662,13 @@ do  --ChangelogTab
 				end
 				local textWidthShrink;
 				if info.bullet then
-					textWidthShrink = Def.ChangelogIndent;
+					if info.bullet == 2 then
+						textWidthShrink = Def.ChangelogIndent2;
+						extraLeftOffset = Def.ChangelogIndent2;
+					else
+						textWidthShrink = Def.ChangelogIndent;
+						extraLeftOffset = Def.ChangelogIndent;
+					end
 				else
 					textWidthShrink = 0;
 				end
@@ -1730,7 +1739,7 @@ do  --ChangelogTab
 						end
 					end
 				else
-					content[n].offsetX = leftOffset + (info.bullet and Def.ChangelogIndent or 0);
+					content[n].offsetX = leftOffset + extraLeftOffset;
 					if info.bullet then
 						n = n + 1;
 						content[n] = {
@@ -1740,13 +1749,14 @@ do  --ChangelogTab
 							bottom = bottom,
 							point = "LEFT",
 							relativePoint = "TOPLEFT",
-							offsetX = leftOffset -6,
+							offsetX = leftOffset + extraLeftOffset - 22,
 							setupFunc = function(obj)
 								obj:SetSize(20, 20);
 								obj:SetTexture(Def.TextureFile);
 								SetTexCoord(obj, 904, 944, 80, 120); --864, 904, 80, 120
 								local color = Def.TextColorReadable;
-								obj:SetVertexColor(color[1], color[2], color[3]);
+								local a = info.bullet == 2 and 0.6 or 1;
+								obj:SetVertexColor(a * color[1], a * color[2], a * color[3]);
 							end;
 						};
 					end

--- a/Modules/ExpansionLandingPage/Retail/ResourceList.lua
+++ b/Modules/ExpansionLandingPage/Retail/ResourceList.lua
@@ -50,8 +50,9 @@ end
 
 do  --MID
 	local ResourceList = {
+		{currencyID = 3418, hasWeeklyCap = true},	--Nebulous Voidcore (Bonus Rolls)
 		{currencyID = 3028},    --Restored Coffer Key
-		{currencyID = 3310, hasWeeklyCap = true},    --Coffer Key Shard
+		{currencyID = 3310, hasWeeklyCap = true},	--Coffer Key Shard
 		{currencyID = 3316},    --Voidlight Marl
 
 		{itemID = 242241, uiMapID = 2395},   --Latent Arcana
@@ -72,7 +73,7 @@ do  --MID
 	};
 
 	if addon.ItemUpgradeConstant.CatalystCurrencyID then
-		table.insert(ResourceList, 1, {
+		table.insert(ResourceList, 2, {
 			currencyID = addon.ItemUpgradeConstant.CatalystCurrencyID,
 			shownIfOwned = true,
 		});

--- a/Modules/GameTooltip_ItemReagents.lua
+++ b/Modules/GameTooltip_ItemReagents.lua
@@ -16,7 +16,6 @@ local IsShiftKeyDown = IsShiftKeyDown;
 
 
 local ItemReagentCache = {};
-local ItemRecipeIDCache = {};   --Debug
 local QuantityOverride = {};
 
 local IgnoredItems = {
@@ -35,7 +34,6 @@ function ItemSubModule:ProcessData(tooltip, itemID)
 				local schematic = GetRecipeSchematic(spellID, false);
 				if schematic and schematic.reagentSlotSchematics then
 					local recipeID = schematic.recipeID;
-					ItemRecipeIDCache[itemID] = recipeID;
 					local numReagents = 0;
 					local reagents = {};
 					local reagentItemID;
@@ -245,5 +243,9 @@ do  --QuantityOverride
 
 	QuantityOverride[468717] = {
 		[231757] = 2,   --Fractured Spark TWW S3
+	};
+
+	QuantityOverride[1283168] = {
+		[268650] = 5,   --Ascendant Voidcore
 	};
 end

--- a/Modules/Housing/Housing_API.lua
+++ b/Modules/Housing/Housing_API.lua
@@ -268,7 +268,7 @@ do  --House Level / Info / Teleport
 	end
 
 	function Housing.ShouldShowTeleportToPlot(factionIndex)
-		if C_HousingNeighborhood.CanReturnAfterVisitingHouse() then
+		if DataProvider.neighborhoodGUIDs and C_HousingNeighborhood.CanReturnAfterVisitingHouse() then
 			local currentNeighborhoodGUID = C_Housing.GetCurrentNeighborhoodGUID();
 			if factionIndex then
 				-- When specifying which house to teleport

--- a/Modules/LootUI_Main.lua
+++ b/Modules/LootUI_Main.lua
@@ -93,7 +93,8 @@ do
 		end
 
 		local fontObject = PlumberLootUIFont;
-		fontObject:SetFont(fontFile, Round(fontSize), "OUTLINE");
+		local fontFlag = "SLUGOUTLINE";
+		fontObject:SetFont(fontFile, Round(fontSize), fontFlag);
 		fontObject:SetShadowOffset(0, 0);
 
 		local locale = GetLocale();

--- a/Modules/LootUI_Main.lua
+++ b/Modules/LootUI_Main.lua
@@ -1215,7 +1215,7 @@ local CreateUIButton
 do  --UI Generic Button (Hotkey Button)
 	local UIButtonMixin = {};
 
-	function UIButtonMixin:SetHotkey(key)
+	function UIButtonMixin:SetHotkeyVisual(key)
 		if key then
 			self.hotkeyName = key;
 			if API.GetModifierKeyName(key) ~= nil then
@@ -1331,11 +1331,9 @@ do  --TakeAllButton
 	function TakeAllButtonMixin:OnEvent(event, ...)
 		if event == "PLAYER_REGEN_DISABLED" then
 			self:SetPropagateKeyboardInput(true);
+			self:UpdateHotKey();
 		elseif event == "PLAYER_REGEN_ENABLED" then
-			if self.hotkeyName and not self.hasOnKeyDownScript then
-				self:SetScript("OnKeyDown", self.OnKeyDown);
-				self.hasOnKeyDownScript = true;
-			end
+			self:UpdateHotKey();
 		elseif event == "MODIFIER_STATE_CHANGED" then
 			local key, down = ...
 			if down == 1 and key == TAKE_ALL_MODIFIER_KEY then
@@ -1345,22 +1343,20 @@ do  --TakeAllButton
 	end
 
 	function TakeAllButtonMixin:OnShow()
-		if MainFrame.inEditMode then return end;
-
-		if self.hotkeyName and (not InCombatLockdown()) or self:GetPropagateKeyboardInput() then
-			self:SetScript("OnKeyDown", self.OnKeyDown);
-			self.hasOnKeyDownScript = true;
+		if MainFrame.inEditMode then
+			self:SetScript("OnKeyDown", nil);
+			self:UnregisterEvent("MODIFIER_STATE_CHANGED");
+			self:SetHotkeyVisual(TAKE_ALL_KEY);
+			return;
 		end
+
 		self:RegisterEvent("PLAYER_REGEN_DISABLED");
 		self:RegisterEvent("PLAYER_REGEN_ENABLED");
-		if TAKE_ALL_MODIFIER_KEY then
-			self:RegisterEvent("MODIFIER_STATE_CHANGED");
-		end
+		self:UpdateHotKey();
 	end
 
 	function TakeAllButtonMixin:OnHide()
 		self:SetScript("OnKeyDown", nil);
-		self.hasOnKeyDownScript = nil;
 		self:UnregisterEvent("PLAYER_REGEN_DISABLED");
 		self:UnregisterEvent("PLAYER_REGEN_ENABLED");
 		self:UnregisterEvent("MODIFIER_STATE_CHANGED");
@@ -1368,11 +1364,19 @@ do  --TakeAllButton
 		self.Highlight:Hide();
 	end
 
-	function TakeAllButtonMixin:UpdateHotKey()
-		if USE_HOTKEY then
-			self:SetHotkey(TAKE_ALL_KEY);
+	function TakeAllButtonMixin:UpdateHotKey(inCombat)
+		self:SetScript("OnKeyDown", nil);
+		self:UnregisterEvent("MODIFIER_STATE_CHANGED");
+
+		if USE_HOTKEY and TAKE_ALL_KEY and (TAKE_ALL_MODIFIER_KEY or (not (InCombatLockdown() or inCombat))) then
+			self:SetHotkeyVisual(TAKE_ALL_KEY);
+			if TAKE_ALL_MODIFIER_KEY then
+				self:RegisterEvent("MODIFIER_STATE_CHANGED");
+			else
+				self:SetScript("OnKeyDown", self.OnKeyDown);
+			end
 		else
-			self:SetHotkey(nil);
+			self:SetHotkeyVisual(nil);
 		end
 	end
 

--- a/Modules/NameplateQuestIndicator.lua
+++ b/Modules/NameplateQuestIndicator.lua
@@ -1133,7 +1133,7 @@ do  --Options
 		local fontFile, fontHeight = GameFontNormalSmall:GetFont();
 		local nameplateFont = PlumberFont_Nameplate_Small;
 		if Def.TextOutline then
-			nameplateFont:SetFont(fontFile, fontHeight, "OUTLINE");
+			nameplateFont:SetFont(fontFile, fontHeight, "SLUGOUTLINE");
 		else
 			nameplateFont:SetFont(fontFile, fontHeight, "");
 		end

--- a/Modules/RaidCheck/DifficultySelector.lua
+++ b/Modules/RaidCheck/DifficultySelector.lua
@@ -24,7 +24,7 @@ local DummyFrame;   --Edit Mode: For Reposition
 
 local function SetupFont(fontString, fontHeight)
 	local font = GameFontNormal:GetFont();
-	fontString:SetFont(font, fontHeight or 14, "OUTLINE");
+	fontString:SetFont(font, fontHeight or 14, "SLUGOUTLINE");
 end
 
 

--- a/Modules/SoftTargetName.lua
+++ b/Modules/SoftTargetName.lua
@@ -81,7 +81,7 @@ do  --Display
 	function Display:UpdateFonts()
 		local file, height, flags = _G[Settings.fontObject]:GetFont();
 		if Settings.textOutline then
-			flags = "OUTLINE";
+			flags = "SLUGOUTLINE";
 		else
 			flags = "";
 		end
@@ -116,7 +116,7 @@ do  --Display
 			self.Title = Display:CreateFontString(nil, "OVERLAY", Settings.fontObject);
 			self.Title:SetPoint("TOP", self, "TOP", 0, 0);
 			local file, height, flags = _G[Settings.fontObject]:GetFont();
-			self.Title:SetFont(file, height, "OUTLINE");
+			self.Title:SetFont(file, height, "SLUGOUTLINE");
 			self.Title:SetShadowOffset(0, 0);
 		end
 

--- a/Modules/TalkingHead.lua
+++ b/Modules/TalkingHead.lua
@@ -222,7 +222,7 @@ function NewTalkingHead:SetFontHeightByPercentage(percentage)
 
 	local style, gray;
 	if DB.TalkingHead_TextOutline then
-		style = "SLUGOUTLINE";
+		style = "OUTLINE";
 		gray = 0.898;   --VERY_LIGHT_GRAY_COLOR
 	else
 		style = "";

--- a/Modules/TalkingHead.lua
+++ b/Modules/TalkingHead.lua
@@ -222,7 +222,7 @@ function NewTalkingHead:SetFontHeightByPercentage(percentage)
 
 	local style, gray;
 	if DB.TalkingHead_TextOutline then
-		style = "OUTLINE";
+		style = "SLUGOUTLINE";
 		gray = 0.898;   --VERY_LIGHT_GRAY_COLOR
 	else
 		style = "";


### PR DESCRIPTION
## Bug Fixes
- **House Macros:** Fixed an error that occurred during the initial login.

- **Loot Window:** The "Take All" hotkey indicator (Default: **E**) now automatically hides when entering combat, meaning the hotkey is disabled due to combat restrictions.
  - _Note: Hotkeys bound to a single modifier key (SHIFT, CTRL, or ALT) remain functional regardless of combat status._

- **Tooltip Reagents:** Corrected the required quantity display for **Ascendant Voidcore** (updated from 4 to 5).
  - _Note: We are aware that some reagent counts may still be off by 1; these are being patched manually as they are identified._

## Added
- **Expansion Summary UI:** Added **Nebulous Voidcore** (bonus rolls) to the resource list.

- **Text Outline:** Used Slug text rendering for certain Plumber fonts, which improves legibility and sharpness when text is displayed at smaller scales.