### PR TITLE
1.9.2 c

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -855,6 +855,7 @@ stds.wow = {
 				"GetItemQualityByID",
 				"GetItemQualityColor",
 				"GetItemSpell",
+				"GetItemStats",
 				"GetItemSubClassInfo",
 				"GetItemUpgradeInfo",
 				"IsCosmeticItem",

--- a/Initialization.lua
+++ b/Initialization.lua
@@ -1,5 +1,5 @@
-local VERSION_TEXT = "1.9.2 b";
-local VERSION_DATE = 1778800000;
+local VERSION_TEXT = "1.9.2 c";
+local VERSION_DATE = 1779500000;
 
 
 local addonName, addon = ...

--- a/Initialization.lua
+++ b/Initialization.lua
@@ -570,7 +570,7 @@ do
 
 	addon.IS_MOP = C_AddOns.GetAddOnMetadata(addonName, "X-Expansion") == "MOP";
 
-	addon.IS_12_0_7 = IsToCVersionEqualOrNewerThan(120005);
+	addon.IS_12_0_7 = IsToCVersionEqualOrNewerThan(120007);
 
 
 	function addon.GetLastLoginTime()

--- a/Initialization.lua
+++ b/Initialization.lua
@@ -570,7 +570,7 @@ do
 
 	addon.IS_MOP = C_AddOns.GetAddOnMetadata(addonName, "X-Expansion") == "MOP";
 
-	addon.IS_12_0_5 = IsToCVersionEqualOrNewerThan(120005);
+	addon.IS_12_0_7 = IsToCVersionEqualOrNewerThan(120005);
 
 
 	function addon.GetLastLoginTime()

--- a/Modules/ControlCenter/Changelog/enUS.lua
+++ b/Modules/ControlCenter/Changelog/enUS.lua
@@ -11,6 +11,37 @@ local changelogs = addon.ControlCenter.changelogs;
 changelogs[10902] = {
 	{
 		type = "date",
+		versionText = "1.9.2 c",
+		timestamp = 1779500000,
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Loot Window: Added a highlight effect to looted pets and equipment with bonus tertiary stats.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Expansion Summary: Fixed a text display issue for \"Prey\" while on the quest \"Preferential Killing.\"",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Tooltips: Vendor location instructions now only display when hovering over items in your bags, rather than on all tooltip sources.",
+	},
+
+	{
+		type = "br",
+	},
+	{
+		type = "br",
+	},
+
+	{
+		type = "date",
 		versionText = "1.9.2 b",
 		timestamp = 1778800000,
 	},

--- a/Modules/ExpansionLandingPage/Basic.lua
+++ b/Modules/ExpansionLandingPage/Basic.lua
@@ -1718,7 +1718,7 @@ do  --Expansion Select
 	local CurrentExpansionID;
 	local ExpansionData = {
 		[11] = {name = EXPANSION_NAME10},   --TWW
-		[12] = {name = EXPANSION_NAME11, isWIP = true},   --MID
+		[12] = {name = EXPANSION_NAME11, isWIP = false},   --MID
 		[5] = {name = EXPANSION_NAME4},     --MOP
 	};
 

--- a/Modules/ExpansionLandingPage/FactionUtil.lua
+++ b/Modules/ExpansionLandingPage/FactionUtil.lua
@@ -157,7 +157,7 @@ local OverrideFactionInfo = {
 do  --Layout MID
 	local MajorFactionLayout = {
 		[1] = {
-			--{factionID = 2792},		--Ritual Sites
+			{factionID = 2792},		--Ritual Sites
 			{factionID = 2764},     --Prey S1
 			{factionID = 2742,      --Delves S1
 				subFactions = {
@@ -184,9 +184,9 @@ do  --Layout MID
 
 	LandingPageUtil.AddExpansionData(12, "factionLayout", MajorFactionLayout);
 
-	if addon.IS_12_0_5 then  --For PTR
-		table.insert(MajorFactionLayout[1], 1, {factionID = 2792});
-	end
+	--if addon.IS_12_0_7 then  --For PTR
+		--table.insert(MajorFactionLayout[1], 1, {factionID = 2792});
+	--end
 end
 
 

--- a/Modules/ExpansionLandingPage/Retail/MID_Activity.lua
+++ b/Modules/ExpansionLandingPage/Retail/MID_Activity.lua
@@ -197,8 +197,8 @@ do
 	--]]
 
 	function SetupFuncs.HuntTable(listButton)
-		local activeQuestID = C_QuestLog.GetActivePreyQuest();
-		if activeQuestID then
+		local activeQuestID = C_QuestLog.GetActivePreyQuest() or 91277; -- Prey: Preferential Killing
+		if C_QuestLog.IsOnQuest(activeQuestID) then
 			listButton:SetQuest(activeQuestID);
 			listButton.flagQuest = activeQuestID;
 			listButton.completed = C_QuestLog.IsQuestFlaggedCompleted(activeQuestID);

--- a/Modules/GameTooltip_VendorLocation.lua
+++ b/Modules/GameTooltip_VendorLocation.lua
@@ -56,6 +56,11 @@ do
 
 		if self.enabled then
 			if ItemData[itemID] and not InCombatLockdown() then
+				local info = tooltip.processingInfo;
+				if not (info and info.getterName == "GetBagItem") then
+					return false;
+				end
+
 				local data = ItemData[itemID];
 				self.currentData = data;
 

--- a/Modules/LootUI_Main.lua
+++ b/Modules/LootUI_Main.lua
@@ -571,12 +571,20 @@ do  --UI ItemButton
 
 	function ItemFrameMixin:SetItem(data)
 		self.singleItemID = data.id;
-		self:SetNameByQuality(data.name, data.quality);
+
+		local showGlow, subtitle = IsRareItem(data);
+
+		if subtitle then
+			self:SetNameByQuality(string.format("%s\n|cff19ff19%s|r", data.name, subtitle), data.quality);
+		else
+			self:SetNameByQuality(data.name, data.quality);
+		end
+
 		self:SetIcon(data.icon, data);
 		self:SetCount(data);
 		self:Layout();
 
-		if IsRareItem(data) then
+		if showGlow then
 			self:ShowGlow(true);
 		else
 			self:ShowGlow(false);
@@ -1995,12 +2003,34 @@ do  --Rare Items
 		[224025] = true,    --Crackling Shard
 	};
 
+	local TertiaryStats = {
+		"ITEM_MOD_CR_LIFESTEAL_SHORT",
+		"ITEM_MOD_CR_AVOIDANCE_SHORT",
+		"ITEM_MOD_CR_SPEED_SHORT",
+		"ITEM_MOD_CR_STURDINESS_SHORT",
+		--"ITEM_MOD_STAMINA_SHORT", -- debug
+	};
+
 	function IsRareItem(data)
 		if RareItems[data.id] then
-			return true
-		elseif data.classID == 15 and data.subclassID == 5 then
-			--Mount
-			return true
+			return true;
+		elseif data.classID == 15 and (data.subclassID == 2 or data.subclassID == 5) then
+			-- CompanionPet/Mount
+			return true;
+		elseif data.classID == 17 then
+			-- Battlepet
+			return true;
+		elseif data.classID == 2 or data.classID == 4 and data.link and C_Item.GetItemStats then
+			-- Equipment with tertiary stats. Retail only.
+			local stats = C_Item.GetItemStats(data.link);
+			if stats then
+				for _, k in ipairs(TertiaryStats) do
+					if stats[k] then
+						local subtitle = _G[k];
+						return true, subtitle;
+					end
+				end
+			end
 		end
 	end
 end

--- a/Modules/LootUI_Main.lua
+++ b/Modules/LootUI_Main.lua
@@ -2011,6 +2011,12 @@ do  --Rare Items
 		--"ITEM_MOD_STAMINA_SHORT", -- debug
 	};
 
+	local ItemStatExclusion = {
+		-- Items that come with tertiaries
+		[251783] = "ITEM_MOD_CR_SPEED_SHORT",	-- Lost Idol of the Hash'ey
+		[262754] = "ITEM_MOD_CR_SPEED_SHORT",	-- Void Pearl of Haste
+	};
+
 	function IsRareItem(data)
 		if RareItems[data.id] then
 			return true;
@@ -2024,8 +2030,9 @@ do  --Rare Items
 			-- Equipment with tertiary stats. Retail only.
 			local stats = C_Item.GetItemStats(data.link);
 			if stats then
+				local excludeStat = ItemStatExclusion[data.id];
 				for _, k in ipairs(TertiaryStats) do
-					if stats[k] then
+					if stats[k] and k ~= excludeStat then
 						local subtitle = _G[k];
 						return true, subtitle;
 					end


### PR DESCRIPTION
- **Loot Window:** Added a highlight effect to looted pets and equipment with bonus tertiary stats.

- **Tooltips: Vendor location** instructions now only display when hovering over items in your bags, rather than on all tooltip sources. #442 

- **Expansion Summary:** Fixed a text display issue for "Prey" while on the quest "Preferential Killing."