### PR TITLE
1.9.2 f

### DIFF
--- a/Initialization.lua
+++ b/Initialization.lua
@@ -1,5 +1,5 @@
-local VERSION_TEXT = "1.9.2 e";
-local VERSION_DATE = 1780400000;
+local VERSION_TEXT = "1.9.2 f";
+local VERSION_DATE = 1781900000;
 
 
 local addonName, addon = ...

--- a/Modules/ControlCenter/Changelog/enUS.lua
+++ b/Modules/ControlCenter/Changelog/enUS.lua
@@ -11,6 +11,36 @@ local changelogs = addon.ControlCenter.changelogs;
 changelogs[10902] = {
 	{
 		type = "date",
+		versionText = "1.9.2 f",
+		timestamp = 1781900000,
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "The Omnium Folio section in Plumber's Expansion Summary UI now stands out more when when you have unselected traits.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Reverted a recent change to text outline rendering method due to compatibility issues.",
+	},
+	{
+		type = "p",
+		bullet = 2,
+		text = "Note: While the switch to Slug rendering provided sharper outlines, it caused rendering problems with certain fonts.",
+	},
+
+	{
+		type = "br",
+	},
+	{
+		type = "br",
+	},
+
+	{
+		type = "date",
 		versionText = "1.9.2 d-e",
 		timestamp = 1780400000,
 	},

--- a/Modules/ControlCenter/Changelog/enUS.lua
+++ b/Modules/ControlCenter/Changelog/enUS.lua
@@ -135,12 +135,6 @@ changelogs[10902] = {
 	},
 
 	{
-		type = "p",
-		bullet = true,
-		text = "Text Outline: Implemented Slug text rendering for certain Plumber fonts, which improves legibility and sharpness when text is displayed at smaller scales.",
-	},
-
-	{
 		type = "br",
 	},
 	{

--- a/Modules/ExpansionLandingPage/Retail/TraitFrame.lua
+++ b/Modules/ExpansionLandingPage/Retail/TraitFrame.lua
@@ -100,14 +100,14 @@ do
 			if info and info.quantity > 0 then
 				local flags, type, currencyTypesID, icon = C_Traits.GetTraitCurrencyInfo(info.traitCurrencyID);
 				self.HeaderFrame:DisplayTraitCurrency(icon, info.quantity);
-				MainFrame.BlackOverlay:Show();
+				self:ShowBlackScreen(true);
 				return true;
 			else
-				MainFrame.BlackOverlay:Hide();
+				self:ShowBlackScreen(false);
 				return false;
 			end
 		else
-			MainFrame.BlackOverlay:Hide();
+			self:ShowBlackScreen(false);
 			return false;
 		end
 	end
@@ -170,6 +170,44 @@ do
 			end
 		end
 		self:ShowHeaderFrame(anyShown);
+	end
+
+	function TraitFrameMixin:ShowBlackScreen(state)
+		if state then
+			if not self.BlackOverlay then
+				local offset = 8;
+				local alpha = 0.8;
+
+				self.BlackOverlay = CreateFrame("Frame", nil, self);
+				self.BlackOverlay:SetUsingParentLevel(true);
+
+				local function CreateOverlay(container)
+					local overlay = self.BlackOverlay:CreateTexture(nil, "BACKGROUND");
+					overlay:SetColorTexture(0, 0, 0, alpha);
+					overlay:SetPoint("TOPLEFT", container, "TOPLEFT", offset, -offset);
+					overlay:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", -offset, offset);
+					return overlay;
+				end
+
+				local overlay1 = CreateOverlay(PlumberExpansionLandingPage.LeftSection);
+				local overlay2 = CreateOverlay(PlumberExpansionLandingPage.RightSection);
+
+				local BackgroundGlow = self.BlackOverlay:CreateTexture(nil, "BACKGROUND", nil, 1);
+				BackgroundGlow:SetSize(256, 256);
+				BackgroundGlow:SetPoint("CENTER", self, "CENTER", 0, 0);
+				BackgroundGlow:SetTexture("Interface/AddOns/Plumber/Art/ExpansionLandingPage/ExpansionLandingPage-BackgroundGlow");
+				BackgroundGlow:SetBlendMode("ADD");
+				local shrink = 48;
+				BackgroundGlow:SetTexCoord(shrink/256, 1-shrink/256, shrink/256, 1-shrink/256);
+				BackgroundGlow:SetVertexColor(60/255, 35/255, 20/255);
+			end
+
+			self.BlackOverlay:Show();
+		else
+			if self.BlackOverlay then
+				self.BlackOverlay:Hide();
+			end
+		end
 	end
 end
 
@@ -404,13 +442,6 @@ function LandingPageUtil.CreateTraitFrame(parent)
 	HeaderFrame:SetScript("OnEnter", HeaderFrame.OnEnter);
 	HeaderFrame:SetScript("OnLeave", HeaderFrame.OnLeave);
 	HeaderFrame:SetScript("OnClick", HeaderFrame.OnClick);
-
-	local container = PlumberExpansionLandingPage.LeftSection;
-	f.BlackOverlay = f:CreateTexture(nil, "BACKGROUND");
-	f.BlackOverlay:Hide();
-	f.BlackOverlay:SetColorTexture(0, 0, 0, 0.8);
-	f.BlackOverlay:SetPoint("TOPLEFT", container, "TOPLEFT", 8, -8);
-	f.BlackOverlay:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", -8, 8);
 
 	return f, height
 end

--- a/Modules/LootUI_Main.lua
+++ b/Modules/LootUI_Main.lua
@@ -93,7 +93,7 @@ do
 		end
 
 		local fontObject = PlumberLootUIFont;
-		local fontFlag = "SLUGOUTLINE";
+		local fontFlag = "OUTLINE";
 		fontObject:SetFont(fontFile, Round(fontSize), fontFlag);
 		fontObject:SetShadowOffset(0, 0);
 

--- a/Modules/NameplateQuestIndicator.lua
+++ b/Modules/NameplateQuestIndicator.lua
@@ -1133,7 +1133,7 @@ do  --Options
 		local fontFile, fontHeight = GameFontNormalSmall:GetFont();
 		local nameplateFont = PlumberFont_Nameplate_Small;
 		if Def.TextOutline then
-			nameplateFont:SetFont(fontFile, fontHeight, "SLUGOUTLINE");
+			nameplateFont:SetFont(fontFile, fontHeight, "OUTLINE");
 		else
 			nameplateFont:SetFont(fontFile, fontHeight, "");
 		end

--- a/Modules/RaidCheck/DifficultySelector.lua
+++ b/Modules/RaidCheck/DifficultySelector.lua
@@ -24,7 +24,7 @@ local DummyFrame;   --Edit Mode: For Reposition
 
 local function SetupFont(fontString, fontHeight)
 	local font = GameFontNormal:GetFont();
-	fontString:SetFont(font, fontHeight or 14, "SLUGOUTLINE");
+	fontString:SetFont(font, fontHeight or 14, "OUTLINE");
 end
 
 

--- a/Modules/SoftTargetName.lua
+++ b/Modules/SoftTargetName.lua
@@ -81,7 +81,7 @@ do  --Display
 	function Display:UpdateFonts()
 		local file, height, flags = _G[Settings.fontObject]:GetFont();
 		if Settings.textOutline then
-			flags = "SLUGOUTLINE";
+			flags = "OUTLINE";
 		else
 			flags = "";
 		end
@@ -116,7 +116,7 @@ do  --Display
 			self.Title = Display:CreateFontString(nil, "OVERLAY", Settings.fontObject);
 			self.Title:SetPoint("TOP", self, "TOP", 0, 0);
 			local file, height, flags = _G[Settings.fontObject]:GetFont();
-			self.Title:SetFont(file, height, "SLUGOUTLINE");
+			self.Title:SetFont(file, height, "OUTLINE");
 			self.Title:SetShadowOffset(0, 0);
 		end
 

--- a/Plumber.toc
+++ b/Plumber.toc
@@ -1,6 +1,6 @@
 ## X-Flavor: retail
 ## X-Expansion: TWW
-## Interface: 120005, 120007
+## Interface: 120007, 120100
 ## Version: 1.9.2
 
 ## Title: Plumber


### PR DESCRIPTION
- The Omnium Folio section in Plumber's Expansion Summary UI now stands out more when you have unselected traits.

- Reverted a recent change to the text outline rendering method due to compatibility issues.
  - Note: While the switch to Slug rendering provided sharper outlines, it caused rendering problems with certain fonts.