### PR TITLE
1.9.3 c

### DIFF
--- a/Initialization.lua
+++ b/Initialization.lua
@@ -1,5 +1,5 @@
-local VERSION_TEXT = "1.9.3 b";
-local VERSION_DATE = 1782700000;
+local VERSION_TEXT = "1.9.3 c";
+local VERSION_DATE = 1783000000;
 
 
 local addonName, addon = ...

--- a/Modules/ControlCenter/Changelog/enUS.lua
+++ b/Modules/ControlCenter/Changelog/enUS.lua
@@ -10,6 +10,31 @@ local changelogs = addon.ControlCenter.changelogs;
 changelogs[10903] = {
 	{
 		type = "date",
+		versionText = "1.9.3 c",
+		timestamp = 1783000000,
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Teleport Home Macro: Fix an issue where the macro stopped working if your house data wasn't fully received during the initial login. Special thanks to foxlit for pointing out the issue.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Expansion Summary UI: When the Plumber minimap button is enabled, WoW's minimap button for Omnium Folio should no longer appear after completing a related quest.",
+	},
+
+	{
+		type = "br",
+	},
+	{
+		type = "br",
+	},
+
+	{
+		type = "date",
 		versionText = "1.9.3 b",
 		timestamp = 1782700000,
 	},

--- a/Modules/ExpansionLandingPage/MinimapButton.lua
+++ b/Modules/ExpansionLandingPage/MinimapButton.lua
@@ -740,6 +740,7 @@ do  --Order Hall, RightClickMenu
 			API.RegisterFrameForEvents(button, GarrisonLandingPageEvents);
 			local forceUpdateIcon = true;
 			button:RefreshButton(forceUpdateIcon);
+			EventRegistry:RegisterCallback("ExpansionLandingPage.OverlayChanged", button.OnOverlayChanged, button);
 		elseif (not state) and not OrderHallUtil.blizzardButtonHidden then
 			OrderHallUtil.blizzardButtonHidden = true;
 			button:UnregisterAllEvents();
@@ -747,6 +748,7 @@ do  --Order Hall, RightClickMenu
 			C_Timer.After(0, function()
 				button:Hide();
 			end);
+			EventRegistry:UnregisterCallback("ExpansionLandingPage.OverlayChanged", button);
 		end
 	end
 

--- a/Modules/Housing/Housing_API.lua
+++ b/Modules/Housing/Housing_API.lua
@@ -173,7 +173,7 @@ do  --House Level / Info / Teleport
 	end
 
 	function DataProvider:LoadHouses()
-		self:RegisterEventCallback("PLAYER_HOUSE_LIST_UPDATED", self.OnHouseListUpdated, true);
+		self:RegisterEventCallback("PLAYER_HOUSE_LIST_UPDATED", self.OnHouseListUpdated);
 		C_Housing.GetPlayerOwnedHouses();   --Tigger PLAYER_HOUSE_LIST_UPDATED
 	end
 


### PR DESCRIPTION
- Fix an issue where the macro stopped working if your house data wasn't fully received during the initial login. Special thanks to foxlit for pointing out the issue. #460 

- When the Plumber minimap button is enabled, WoW's minimap button for Omnium Folio should no longer appear after completing a related quest.​ #459