### PR TITLE
1.9.4 c

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -4535,24 +4535,10 @@ do  -- Delves
 		else
 			GameTooltip_SetTitle(tooltip, WEEKLY_REWARDS_CURRENT_REWARD);
 
-
-			--[[
-			--This default method is unreliable since 11.2.0, so we hardcode itemlevel
-			local itemLink, upgradeItemLink = C_WeeklyRewards.GetExampleRewardItemHyperlinks(id);
-			local itemLevel, upgradeItemLevel;
-
-			if itemLink then
-				itemLevel = C_Item.GetDetailedItemLevelInfo(itemLink);
-			end
-			if upgradeItemLink then
-				upgradeItemLevel = C_Item.GetDetailedItemLevelInfo(upgradeItemLink);
-			end
-			--]]
-
-			local itemLevel = API.GetDelvesGreatVaultItemLevel(level);
+			local itemLevel = API.GetDelvesGreatVaultItemLevel(level, id);
 
 			local nextLevel = level + 1;
-			local upgradeItemLevel = API.GetDelvesGreatVaultItemLevel(nextLevel);
+			local upgradeItemLevel = API.GetDelvesGreatVaultItemLevel(nextLevel, id, true);
 
 			if level > 0 and itemLevel then
 				GameTooltip_AddNormalLine(tooltip, string.format(WEEKLY_REWARDS_ITEM_LEVEL_WORLD, itemLevel, level));

--- a/Initialization.lua
+++ b/Initialization.lua
@@ -1,5 +1,5 @@
-local VERSION_TEXT = "1.9.4 b";
-local VERSION_DATE = 1786800000;
+local VERSION_TEXT = "1.9.4 c";
+local VERSION_DATE = 1787500000;
 
 
 local addonName, addon = ...

--- a/Modules/ControlCenter/Changelog/enUS.lua
+++ b/Modules/ControlCenter/Changelog/enUS.lua
@@ -10,6 +10,42 @@ local changelogs = addon.ControlCenter.changelogs;
 changelogs[10904] = {
 	{
 		type = "date",
+		versionText = "1.9.4 c",
+		timestamp = 1787500000,
+	},
+
+	{
+		type = "h1",
+		text = "Bug Fixes",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Expansion Summary UI: Fixed the wrong item level in the World activity's tooltip.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Nameplate: Soft Target: Fixed an issue that caused rare/elite icons on the nameplate to disappear.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Hunt Table: The extra tooltip for the Prey Season 2 intro quest should no longer appear if you are not on the quest.",
+	},
+
+	{
+		type = "br",
+	},
+	{
+		type = "br",
+	},
+
+	{
+		type = "date",
 		versionText = "1.9.4 b",
 		timestamp = 1786800000,
 	},

--- a/Modules/ExpansionLandingPage/GreatVault.lua
+++ b/Modules/ExpansionLandingPage/GreatVault.lua
@@ -169,11 +169,9 @@ do
 					if activityInfo then
 						itemLevel, upgradeItemLevel, itemLink = nil, nil, nil;
 
-						--[[ -- Disable this because of S2, let's see if WoW API breaks again :)
 						if row == 3 then
-							itemLevel = API.GetDelvesGreatVaultItemLevel(activityInfo.level);
+							itemLevel = API.GetDelvesGreatVaultItemLevel(activityInfo.level, activityInfo.id);
 						end
-						--]]
 
 						if not itemLevel then
 							itemLink, upgradeItemLink = C_WeeklyRewards.GetExampleRewardItemHyperlinks(activityInfo.id);

--- a/Modules/ExpansionLandingPage/Retail/MID_Activity.lua
+++ b/Modules/ExpansionLandingPage/Retail/MID_Activity.lua
@@ -485,6 +485,23 @@ local ActivityData = {
 		},
 	},
 
+	{isHeader = true, name = "Zul'jarra's Forces", factionID = 2772, categoryID = 2772, uiMapID = 2512,
+			entries = {
+				{name = "Turn Back the Surge", questID = 96995, isWeeklyQuest = true, uiMapID = 2512, sortToTop = true},
+
+				-- (Underground) Vaults of Atal'Utek
+				{name = "Purging the Vaults", questID = 95520, isWeeklyQuest = true, uiMapID = 2509, sortToTop = true},
+				-- Group Daily
+				{name = "Patrolling the Temple", questID = 96639, uiMapID = 2509, shownIfActive = true},
+				{name = "Bounty of the Cursed", questID = 96640, uiMapID = 2509, shownIfActive = true},
+				{name = "Relentless Strikes", questID = 96641, uiMapID = 2509, shownIfActive = true},
+				{name = "Decisive Incursions", questID = 96642, uiMapID = 2509, shownIfActive = true},
+				{name = "From Whence it Came", questID = 96643, uiMapID = 2509, shownIfActive = true},
+				{name = "Essence of Malice", questID = 96644, uiMapID = 2509, shownIfActive = true},
+				{name = "What's Out There?", questID = 98420, uiMapID = 2509, shownIfActive = true},
+		},
+	},
+
 	{isHeader = true, name = "Silvermoon Court", factionID = 2710, categoryID = 2710, uiMapID = 2395,
 		entries = {
 			{name = "Favor of the Court", questID = 89289, isWeeklyQuest = true, uiMapID = 2395, sortToTop = true},
@@ -557,25 +574,9 @@ local ActivityData = {
 	},
 };
 
-if addon.IS_12_1_0 then
-	local CoiledIsleActivity = {isHeader = true, name = "Zul'jarra's Forces", factionID = 2772, categoryID = 2772, uiMapID = 2512,
-		entries = {
-			{name = "Turn Back the Surge", questID = 96995, isWeeklyQuest = true, uiMapID = 2512, sortToTop = true},
-
-			-- (Underground) Vaults of Atal'Utek
-			{name = "Purging the Vaults", questID = 95520, isWeeklyQuest = true, uiMapID = 2509, sortToTop = true},
-			-- Group Daily
-			{name = "Patrolling the Temple", questID = 96639, uiMapID = 2509, shownIfActive = true}, -- √
-			{name = "Bounty of the Cursed", questID = 96640, uiMapID = 2509, shownIfActive = true},
-			{name = "Relentless Strikes", questID = 96641, uiMapID = 2509, shownIfActive = true},
-			{name = "Decisive Incursions", questID = 96642, uiMapID = 2509, shownIfActive = true}, -- √
-			{name = "From Whence it Came", questID = 96643, uiMapID = 2509, shownIfActive = true},
-			{name = "Essence of Malice", questID = 96644, uiMapID = 2509, shownIfActive = true}, -- √
-			{name = "What's Out There?", questID = 98420, uiMapID = 2509, shownIfActive = true}, -- √
-		},
-	};
-
-	table.insert(ActivityData, 2, CoiledIsleActivity);
+if addon.IS_12_1_5 then
+	--local newEntries = {};
+	--table.insert(ActivityData, 3, newEntries);
 end
 
 

--- a/Modules/HuntTable.lua
+++ b/Modules/HuntTable.lua
@@ -90,7 +90,7 @@ local function SetupPin(pin)
 			description = description.."\n\n"..L["Prey Target Has Achievement"];
 		end
 
-		if rootQuestID then
+		if rootQuestID and C_QuestLog.IsOnQuest(rootQuestID) then
 			local questName = addon.API.GetQuestName(rootQuestID);
 			if questName then
 				description = description.."\n\n"..string.format(L["Quest Objective Entry Format"], "|cffffffff"..questName.."|r");

--- a/Modules/Shared/SharedData.lua
+++ b/Modules/Shared/SharedData.lua
@@ -162,21 +162,21 @@ do  --Weekly Caches (Meta quest rewards)
 
 		DelvesGreatVaultItemLevel = {
 			--Hardcode this because BLZ API is unreliable in 11.2.0
-			233,
-			237,
-			240,
-			243,
-			246,
+			279,
+			282,
+			285,
+			289,
+			292,
 
-			250,
-			256,
-			259,    --Tier 8 Max
-			259,
-			259,
+			295,
+			298,
+			305,    --Tier 8 Max
+			305,
+			305,
 
-			259,
-			263,
-			269,
+			305,
+			305,
+			305,
 		},
 
 		GreatVaultWorldActivityMaxLevel = 13,
@@ -186,8 +186,21 @@ do  --Weekly Caches (Meta quest rewards)
 	addon.WeeklyRewardsConstant = WeeklyRewardsConstant;
 
 
-	function API.GetDelvesGreatVaultItemLevel(tier)
-		return WeeklyRewardsConstant.DelvesGreatVaultItemLevel[tier]
+	local USE_HARDCODED_ITEM_LEVEL = true; -- Disable this when new season starts where the levels are not settled.
+	--- Use a hardcoded list to fix the occasional wrong item level issue.
+	---@param tier number
+	---@param id number activityInfo.id
+	---@param getNextTierItemLevel boolean?
+	function API.GetDelvesGreatVaultItemLevel(tier, id, getNextTierItemLevel)
+		if USE_HARDCODED_ITEM_LEVEL then
+			return WeeklyRewardsConstant.DelvesGreatVaultItemLevel[tier];
+		elseif id then
+			local itemLink, upgradeItemLink = C_WeeklyRewards.GetExampleRewardItemHyperlinks(id);
+			local link = (getNextTierItemLevel and upgradeItemLink) or itemLink;
+			if link then
+				return C_Item.GetDetailedItemLevelInfo(link);
+			end
+		end
 	end
 end
 

--- a/Modules/SoftTargetName.lua
+++ b/Modules/SoftTargetName.lua
@@ -616,10 +616,10 @@ do  --EL
 				Display:Hide();
 			end
 
-			--Fix the Elite icon on GameObject namepalte
+			--Fix the Elite icon on GameObject nameplate
 			--CompactUnitFrame_UpdateClassificationIndicator(nameplate.UnitFrame);
-			if nameplate.UnitFrame.classificationIndicator then
-				nameplate.UnitFrame.classificationIndicator:Hide();
+			if nameplate.UnitFrame.ClassificationFrame then
+				nameplate.UnitFrame.ClassificationFrame:Hide();
 			end
 		else
 			Display:Hide();


### PR DESCRIPTION
## Bug Fixes
- **Expansion Summary UI:** Fixed the wrong item level in the World activity's tooltip.

- **Nameplate: Soft Target:** Fixed an issue that caused rare/elite icons on the nameplate to disappear.

- **Hunt Table:** The extra tooltip for the Prey Season 2 intro quest should no longer appear if you are not on the quest. 