### PR TITLE
Add Transmog UI: Restore Pending Changes

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1280,6 +1280,7 @@ stds.wow = {
 				"GetSecondarySlotState",
 				"GetTransmogOutfitSlotFromInventorySlot",
 				"GetViewedOutfitSlotInfo",
+				"GetWeaponOptionsForSlot",
 				"HasPendingOutfitTransmogs",
 				"IsEquippedGearOutfitDisplayed",
 				"IsLockedOutfit",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -465,6 +465,7 @@ stds.wow = {
 		"TransmogFrame",
 		"TransmogAndMountDressupFrame",
 		"Transmog_LoadUI",
+		"TransmogUtil",
 		"UIErrorsFrame",
 		"UIParent",
 		"UISpecialFrames",
@@ -1264,6 +1265,7 @@ stds.wow = {
 				"GetSourceInfo",
 				"GetSourceItemID",
 				"GetValidAppearanceSourcesForClass",
+				"IsAppearanceHiddenVisual",
 				"IsSearchInProgress",
 				"PlayerHasTransmogItemModifiedAppearance",
 			},
@@ -1273,10 +1275,16 @@ stds.wow = {
 			fields = {
 				"ChangeToOutfit",
 				"GetActiveOutfitID",
+				"GetEquippedSlotOptionFromTransmogSlot",
 				"GetOutfitsInfo",
+				"GetSecondarySlotState",
+				"GetTransmogOutfitSlotFromInventorySlot",
+				"HasPendingOutfitTransmogs",
 				"IsEquippedGearOutfitDisplayed",
 				"IsLockedOutfit",
 				"PickupOutfit",
+				"SetPendingTransmog",
+				"SetSecondarySlotState",
 			},
 		},
 
@@ -1554,9 +1562,37 @@ stds.wow = {
 					},
 				},
 
+				TransmogOutfitDisplayType = {
+					fields = {
+						"Assigned",
+						"Hidden",
+						"Unassigned",
+					},
+				},
+
+				TransmogOutfitSlot = {
+					fields = {
+						"ShoulderLeft",
+						"ShoulderRight",
+					},
+				},
+
+				TransmogOutfitSlotOption = {
+					fields = {
+						"None",
+					},
+				},
+
 				TransmogPendingType = {
 					fields = {
 						"Apply",
+					},
+				},
+
+				TransmogType = {
+					fields = {
+						"Appearance",
+						"Illusion",
 					},
 				},
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1279,11 +1279,13 @@ stds.wow = {
 				"GetOutfitsInfo",
 				"GetSecondarySlotState",
 				"GetTransmogOutfitSlotFromInventorySlot",
+				"GetViewedOutfitSlotInfo",
 				"HasPendingOutfitTransmogs",
 				"IsEquippedGearOutfitDisplayed",
 				"IsLockedOutfit",
 				"PickupOutfit",
 				"SetPendingTransmog",
+				"SetPendingTransmogSheatheCategory",
 				"SetSecondarySlotState",
 			},
 		},
@@ -1574,6 +1576,8 @@ stds.wow = {
 					fields = {
 						"ShoulderLeft",
 						"ShoulderRight",
+						"WeaponMainHand",
+						"WeaponOffHand",
 					},
 				},
 

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -805,6 +805,11 @@ L["Quick Access Outfit Button"] = "Quick Access";
 L["Quick Access Outfit Button Tooltip"] = "Click and drag this button to your action bars so you can change outfits anywhere.";
 
 
+--TransmogRestorePending
+L["ModuleName TransmogRestorePending"] = "Transmog UI: Restore Pending Changes";
+L["ModuleDescription TransmogRestorePending"] = "Your pending Transmog changes are restored automatically the next time you open the window.";
+
+
 --QuestWatchCycle
 L["ModuleName QuestWatchCycle"] = "Keybindings: Focus On Quest";
 L["ModuleDescription QuestWatchCycle"] = "Allows you to press hotkeys to focus on the next/previous quest in the objective tracker.\n\n|cffd4641cSet your hotkeys in Keybindings> Plumber Addon.|r";

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -48,7 +48,7 @@ do
 		end
 	end
 
-	local function ApplySnapshotToPending(itemTransmogInfoList)
+	function EL.ApplySnapshotToPending(itemTransmogInfoList)
 		for invSlotID, transmogInfo in ipairs(itemTransmogInfoList) do
 			if not IgnoredInvSlots[invSlotID] then
 				local transmogID = transmogInfo.appearanceID;
@@ -74,14 +74,12 @@ do
 			end
 		end
 	end
-	EL.ApplySnapshotToPending = ApplySnapshotToPending;
 
-	local function RestoreShoulderSecondaryState(enabled)
+	function EL.RestoreShoulderSecondaryState(enabled)
 		if enabled ~= nil then
 			C_TransmogOutfitInfo.SetSecondarySlotState(SHOULDER_RIGHT, enabled);
 		end
 	end
-	EL.RestoreShoulderSecondaryState = RestoreShoulderSecondaryState;
 
 	local function GetWeaponSheatheCategory(slot, weaponOption)
 		if not slot or not weaponOption or weaponOption == Enum.TransmogOutfitSlotOption.None then return nil end;
@@ -90,7 +88,7 @@ do
 		return slotInfo and slotInfo.sheatheCategory;
 	end
 
-	local function CaptureWeaponSheatheCategories()
+	function EL.CaptureWeaponSheatheCategories()
 		local sheatheCategories;
 		for invSlotID, slot in pairs(WEAPON_SLOTS) do
 			local weaponOption = C_TransmogOutfitInfo.GetEquippedSlotOptionFromTransmogSlot(slot);
@@ -102,9 +100,8 @@ do
 		end
 		return sheatheCategories;
 	end
-	EL.CaptureWeaponSheatheCategories = CaptureWeaponSheatheCategories;
 
-	local function RestoreWeaponSheatheCategories(sheatheCategories)
+	function EL.RestoreWeaponSheatheCategories(sheatheCategories)
 		if not sheatheCategories then return end;
 
 		for invSlotID, slot in pairs(WEAPON_SLOTS) do
@@ -118,16 +115,14 @@ do
 			end
 		end
 	end
-	EL.RestoreWeaponSheatheCategories = RestoreWeaponSheatheCategories;
 
-	local function ForceWeaponSlotWidgetRebuild()
+	function EL.ForceWeaponSlotWidgetRebuild()
 		--Toggling shoulder secondary state forces a weapon slot widget rebuild, working around a Blizzard display
 		--bug where the widget caches the wrong option (e.g. 1H for an equipped 2H) on first build. Must run first.
 		local liveSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
 		C_TransmogOutfitInfo.SetSecondarySlotState(SHOULDER_RIGHT, not liveSecondary);
 		C_TransmogOutfitInfo.SetSecondarySlotState(SHOULDER_RIGHT, liveSecondary);
 	end
-	EL.ForceWeaponSlotWidgetRebuild = ForceWeaponSlotWidgetRebuild;
 end
 
 
@@ -165,7 +160,7 @@ do
 	end
 	EL.SaveSnapshotToDB = SaveSnapshotToDB;
 
-	local function LoadSnapshotFromDB()
+	function EL.LoadSnapshotFromDB()
 		local saved = PlumberDB_PC and PlumberDB_PC.TransmogRestorePending;
 		if saved then
 			if type(saved.snapshot) == "string" then
@@ -178,7 +173,6 @@ do
 			EL.pendingSheatheCategories = saved.sheatheCategories;
 		end
 	end
-	EL.LoadSnapshotFromDB = LoadSnapshotFromDB;
 
 	local function CaptureSnapshot()
 		if not EL.enabled then return end;
@@ -238,7 +232,7 @@ do
 		EL:UnregisterAllEvents();
 	end
 
-	local function SnapshotFrame_OnLoad()
+	function EL.SnapshotFrame_OnLoad()
 		if EL.snapshotHooked then return end;
 		EL.snapshotHooked = true;
 
@@ -250,7 +244,6 @@ do
 			TransmogFrame_OnShow();
 		end
 	end
-	EL.SnapshotFrame_OnLoad = SnapshotFrame_OnLoad;
 end
 
 

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -3,6 +3,10 @@ local L = addon.L;
 
 local EL = CreateFrame("Frame");
 local SHOULDER_RIGHT = Enum.TransmogOutfitSlot.ShoulderRight;
+local WEAPON_SLOTS = {
+	[16] = Enum.TransmogOutfitSlot.WeaponMainHand,
+	[17] = Enum.TransmogOutfitSlot.WeaponOffHand,
+};
 
 
 do
@@ -79,6 +83,43 @@ do
 	end
 	EL.RestoreShoulderSecondaryState = RestoreShoulderSecondaryState;
 
+	local function GetWeaponSheatheCategory(slot, weaponOption)
+		if not slot or not weaponOption or weaponOption == Enum.TransmogOutfitSlotOption.None then return nil end;
+
+		local slotInfo = C_TransmogOutfitInfo.GetViewedOutfitSlotInfo(slot, Enum.TransmogType.Appearance, weaponOption);
+		return slotInfo and slotInfo.sheatheCategory;
+	end
+
+	local function CaptureWeaponSheatheCategories()
+		local sheatheCategories;
+		for invSlotID, slot in pairs(WEAPON_SLOTS) do
+			local weaponOption = C_TransmogOutfitInfo.GetEquippedSlotOptionFromTransmogSlot(slot);
+			local category = GetWeaponSheatheCategory(slot, weaponOption);
+			if category then
+				sheatheCategories = sheatheCategories or {};
+				sheatheCategories[invSlotID] = category;
+			end
+		end
+		return sheatheCategories;
+	end
+	EL.CaptureWeaponSheatheCategories = CaptureWeaponSheatheCategories;
+
+	local function RestoreWeaponSheatheCategories(sheatheCategories)
+		if not sheatheCategories then return end;
+
+		for invSlotID, slot in pairs(WEAPON_SLOTS) do
+			local category = sheatheCategories[invSlotID];
+			if category then
+				--Must match the equipped weapon's current option, or SetPendingTransmogSheatheCategory silently does nothing
+				local weaponOption = C_TransmogOutfitInfo.GetEquippedSlotOptionFromTransmogSlot(slot);
+				if weaponOption and weaponOption ~= Enum.TransmogOutfitSlotOption.None then
+					C_TransmogOutfitInfo.SetPendingTransmogSheatheCategory(slot, weaponOption, category);
+				end
+			end
+		end
+	end
+	EL.RestoreWeaponSheatheCategories = RestoreWeaponSheatheCategories;
+
 	local function ForceWeaponSlotWidgetRebuild()
 		--Toggling shoulder secondary state forces a weapon slot widget rebuild, working around a Blizzard display
 		--bug where the widget caches the wrong option (e.g. 1H for an equipped 2H) on first build. Must run first.
@@ -116,6 +157,7 @@ do
 			PlumberDB_PC.TransmogRestorePending = {
 				snapshot = SerializeSnapshot(EL.pendingSnapshot),
 				shoulderSecondary = EL.pendingShoulderSecondary,
+				sheatheCategories = EL.pendingSheatheCategories,
 			};
 		else
 			PlumberDB_PC.TransmogRestorePending = nil;
@@ -133,6 +175,7 @@ do
 				EL.pendingSnapshot = saved.snapshot;
 			end
 			EL.pendingShoulderSecondary = saved.shoulderSecondary;
+			EL.pendingSheatheCategories = saved.sheatheCategories;
 		end
 	end
 	EL.LoadSnapshotFromDB = LoadSnapshotFromDB;
@@ -143,9 +186,11 @@ do
 		if not C_TransmogOutfitInfo.HasPendingOutfitTransmogs() then
 			EL.pendingSnapshot = nil;
 			EL.pendingShoulderSecondary = nil;
+			EL.pendingSheatheCategories = nil;
 		else
 			EL.pendingSnapshot = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
 			EL.pendingShoulderSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
+			EL.pendingSheatheCategories = EL.CaptureWeaponSheatheCategories();
 		end
 
 		SaveSnapshotToDB();
@@ -155,8 +200,10 @@ do
 		--Clear early, a write below can retrigger CaptureSnapshot mid-call
 		local snapshot = EL.pendingSnapshot;
 		local shoulderSecondary = EL.pendingShoulderSecondary;
+		local sheatheCategories = EL.pendingSheatheCategories;
 		EL.pendingSnapshot = nil;
 		EL.pendingShoulderSecondary = nil;
+		EL.pendingSheatheCategories = nil;
 		EL.SaveSnapshotToDB();
 
 		EL.ForceWeaponSlotWidgetRebuild();
@@ -164,6 +211,8 @@ do
 		--Must run before ApplySnapshotToPending, toggling this after would wipe the left shoulder's pending value
 		EL.RestoreShoulderSecondaryState(shoulderSecondary);
 		EL.ApplySnapshotToPending(snapshot);
+		--Must run after ApplySnapshotToPending, setting a weapon's appearance resets its sheathe category to Default
+		EL.RestoreWeaponSheatheCategories(sheatheCategories);
 		--If we ever want to notify the user their outfit was restored, this is where it'd happen.
 	end
 
@@ -216,6 +265,7 @@ do
 			addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_Transmog", EL.SnapshotFrame_OnLoad);
 			EL.pendingSnapshot = nil;
 			EL.pendingShoulderSecondary = nil;
+			EL.pendingSheatheCategories = nil;
 			EL.SaveSnapshotToDB();
 		end
 	end

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -16,6 +16,8 @@ do
 		[12] = true,    --Finger2
 		[13] = true,    --Trinket1
 		[14] = true,    --Trinket2
+		[16] = true,    --MainHand, see CaptureWeaponOptionsPending
+		[17] = true,    --SecondaryHand, see CaptureWeaponOptionsPending
 		[18] = true,    --Ranged
 	};
 
@@ -63,13 +65,7 @@ do
 					SetPendingFromSlot(invSlotID, Enum.TransmogOutfitSlot.ShoulderLeft, secondaryAppearanceID);
 				else
 					local slot = C_TransmogOutfitInfo.GetTransmogOutfitSlotFromInventorySlot(invSlotID - 1);
-					local illusionID, weaponOption;
-					if invSlotID == 16 or invSlotID == 17 then
-						--Weapon slots must be written under the equipped weapon's option, or SetPendingTransmog silently does nothing
-						illusionID = transmogInfo.illusionID;
-						weaponOption = slot and C_TransmogOutfitInfo.GetEquippedSlotOptionFromTransmogSlot(slot);
-					end
-					SetPendingFromSlot(invSlotID, slot, transmogID, illusionID, weaponOption);
+					SetPendingFromSlot(invSlotID, slot, transmogID);
 				end
 			end
 		end
@@ -81,37 +77,72 @@ do
 		end
 	end
 
-	local function GetWeaponSheatheCategory(slot, weaponOption)
-		if not slot or not weaponOption or weaponOption == Enum.TransmogOutfitSlotOption.None then return nil end;
+	--Records are {invSlotID, weaponOption, transmogID, illusionID, sheatheCategory}, false marks a field as not captured
+	local function CaptureWeaponOptionRecord(invSlotID, slot, weaponOption)
+		local transmogID, illusionID, sheatheCategory;
 
-		local slotInfo = C_TransmogOutfitInfo.GetViewedOutfitSlotInfo(slot, Enum.TransmogType.Appearance, weaponOption);
-		return slotInfo and slotInfo.sheatheCategory;
+		--hasPending means unsaved, not just currently equipped or already saved
+		local appearanceInfo = C_TransmogOutfitInfo.GetViewedOutfitSlotInfo(slot, Enum.TransmogType.Appearance, weaponOption);
+		if appearanceInfo and appearanceInfo.hasPending then
+			transmogID = appearanceInfo.transmogID;
+			sheatheCategory = appearanceInfo.sheatheCategory;
+		end
+
+		local illusionInfo = C_TransmogOutfitInfo.GetViewedOutfitSlotInfo(slot, Enum.TransmogType.Illusion, weaponOption);
+		if illusionInfo and illusionInfo.hasPending then
+			illusionID = illusionInfo.transmogID;
+		end
+
+		if transmogID or illusionID then
+			return {invSlotID, weaponOption, transmogID or false, illusionID or false, sheatheCategory or false};
+		end
 	end
 
-	function EL.CaptureWeaponSheatheCategories()
-		local sheatheCategories;
-		for invSlotID, slot in pairs(WEAPON_SLOTS) do
-			local weaponOption = C_TransmogOutfitInfo.GetEquippedSlotOptionFromTransmogSlot(slot);
-			local category = GetWeaponSheatheCategory(slot, weaponOption);
-			if category then
-				sheatheCategories = sheatheCategories or {};
-				sheatheCategories[invSlotID] = category;
+	--Shared so the same capture logic runs for both weaponOptionsInfo and artifactOptionsInfo without duplicating it
+	local function CaptureOptionsInfoList(weaponOptionsPending, invSlotID, slot, optionsInfo)
+		if not optionsInfo then return weaponOptionsPending end;
+
+		for _, optionInfo in ipairs(optionsInfo) do
+			if optionInfo.enabled then
+				local record = CaptureWeaponOptionRecord(invSlotID, slot, optionInfo.weaponOption);
+				if record then
+					weaponOptionsPending = weaponOptionsPending or {};
+					table.insert(weaponOptionsPending, record);
+				end
 			end
 		end
-		return sheatheCategories;
+
+		return weaponOptionsPending;
 	end
 
-	function EL.RestoreWeaponSheatheCategories(sheatheCategories)
-		if not sheatheCategories then return end;
-
+	function EL.CaptureWeaponOptionsPending()
+		local weaponOptionsPending;
 		for invSlotID, slot in pairs(WEAPON_SLOTS) do
-			local category = sheatheCategories[invSlotID];
-			if category then
-				--Must match the equipped weapon's current option, or SetPendingTransmogSheatheCategory silently does nothing
-				local weaponOption = C_TransmogOutfitInfo.GetEquippedSlotOptionFromTransmogSlot(slot);
-				if weaponOption and weaponOption ~= Enum.TransmogOutfitSlotOption.None then
-					C_TransmogOutfitInfo.SetPendingTransmogSheatheCategory(slot, weaponOption, category);
-				end
+			--Artifact spec options use separate enum values, so they never collide with the weapon options here
+			local weaponOptionsInfo, artifactOptionsInfo = C_TransmogOutfitInfo.GetWeaponOptionsForSlot(slot);
+			weaponOptionsPending = CaptureOptionsInfoList(weaponOptionsPending, invSlotID, slot, weaponOptionsInfo);
+			weaponOptionsPending = CaptureOptionsInfoList(weaponOptionsPending, invSlotID, slot, artifactOptionsInfo);
+		end
+		return weaponOptionsPending;
+	end
+
+	function EL.RestoreWeaponOptionsPending(weaponOptionsPending)
+		if not weaponOptionsPending then return end;
+
+		for _, record in ipairs(weaponOptionsPending) do
+			local invSlotID, weaponOption, transmogID, illusionID, sheatheCategory = record[1], record[2], record[3], record[4], record[5];
+			local slot = WEAPON_SLOTS[invSlotID];
+
+			if transmogID then
+				SetPendingFromSlot(invSlotID, slot, transmogID, illusionID, weaponOption);
+			elseif illusionID then
+				--SetPendingFromSlot already writes the illusion when transmogID is set, this covers illusion-only changes
+				local illusionDisplayType = (illusionID == 0) and Enum.TransmogOutfitDisplayType.Unassigned or Enum.TransmogOutfitDisplayType.Assigned;
+				C_TransmogOutfitInfo.SetPendingTransmog(slot, Enum.TransmogType.Illusion, weaponOption, illusionID, illusionDisplayType);
+			end
+
+			if sheatheCategory then
+				C_TransmogOutfitInfo.SetPendingTransmogSheatheCategory(slot, weaponOption, sheatheCategory);
 			end
 		end
 	end
@@ -152,7 +183,7 @@ do
 			PlumberDB_PC.TransmogRestorePending = {
 				snapshot = SerializeSnapshot(EL.pendingSnapshot),
 				shoulderSecondary = EL.pendingShoulderSecondary,
-				sheatheCategories = EL.pendingSheatheCategories,
+				weaponOptions = EL.pendingWeaponOptions,
 			};
 		else
 			PlumberDB_PC.TransmogRestorePending = nil;
@@ -170,7 +201,7 @@ do
 				EL.pendingSnapshot = saved.snapshot;
 			end
 			EL.pendingShoulderSecondary = saved.shoulderSecondary;
-			EL.pendingSheatheCategories = saved.sheatheCategories;
+			EL.pendingWeaponOptions = saved.weaponOptions;
 		end
 	end
 
@@ -180,11 +211,11 @@ do
 		if not C_TransmogOutfitInfo.HasPendingOutfitTransmogs() then
 			EL.pendingSnapshot = nil;
 			EL.pendingShoulderSecondary = nil;
-			EL.pendingSheatheCategories = nil;
+			EL.pendingWeaponOptions = nil;
 		else
 			EL.pendingSnapshot = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
 			EL.pendingShoulderSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
-			EL.pendingSheatheCategories = EL.CaptureWeaponSheatheCategories();
+			EL.pendingWeaponOptions = EL.CaptureWeaponOptionsPending();
 		end
 
 		SaveSnapshotToDB();
@@ -194,10 +225,10 @@ do
 		--Clear early, a write below can retrigger CaptureSnapshot mid-call
 		local snapshot = EL.pendingSnapshot;
 		local shoulderSecondary = EL.pendingShoulderSecondary;
-		local sheatheCategories = EL.pendingSheatheCategories;
+		local weaponOptions = EL.pendingWeaponOptions;
 		EL.pendingSnapshot = nil;
 		EL.pendingShoulderSecondary = nil;
-		EL.pendingSheatheCategories = nil;
+		EL.pendingWeaponOptions = nil;
 		EL.SaveSnapshotToDB();
 
 		EL.ForceWeaponSlotWidgetRebuild();
@@ -206,7 +237,7 @@ do
 		EL.RestoreShoulderSecondaryState(shoulderSecondary);
 		EL.ApplySnapshotToPending(snapshot);
 		--Must run after ApplySnapshotToPending, setting a weapon's appearance resets its sheathe category to Default
-		EL.RestoreWeaponSheatheCategories(sheatheCategories);
+		EL.RestoreWeaponOptionsPending(weaponOptions);
 		--If we ever want to notify the user their outfit was restored, this is where it'd happen.
 	end
 
@@ -258,7 +289,7 @@ do
 			addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_Transmog", EL.SnapshotFrame_OnLoad);
 			EL.pendingSnapshot = nil;
 			EL.pendingShoulderSecondary = nil;
-			EL.pendingSheatheCategories = nil;
+			EL.pendingWeaponOptions = nil;
 			EL.SaveSnapshotToDB();
 		end
 	end

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -1,0 +1,233 @@
+local _, addon = ...
+local L = addon.L;
+
+local EL = CreateFrame("Frame");
+local SHOULDER_RIGHT = Enum.TransmogOutfitSlot.ShoulderRight;
+
+
+do
+	local IgnoredInvSlots = {
+		[2] = true,     --Neck
+		[11] = true,    --Finger1
+		[12] = true,    --Finger2
+		[13] = true,    --Trinket1
+		[14] = true,    --Trinket2
+		[18] = true,    --Ranged
+	};
+
+	local function SetPendingFromSlot(invSlotID, slot, transmogID, illusionID, weaponOption)
+		local option = weaponOption or Enum.TransmogOutfitSlotOption.None;
+		local transmogType, displayType;
+
+		if illusionID then
+			--Illusions get their own pending entry, separate from the appearance
+			transmogType = Enum.TransmogType.Illusion;
+			displayType = (illusionID == 0) and Enum.TransmogOutfitDisplayType.Unassigned or Enum.TransmogOutfitDisplayType.Assigned;
+			C_TransmogOutfitInfo.SetPendingTransmog(slot, transmogType, option, illusionID, displayType);
+		end
+
+		transmogType = Enum.TransmogType.Appearance;
+
+		local isHiddenVisual = C_TransmogCollection.IsAppearanceHiddenVisual(transmogID) or transmogID == 0;
+		if isHiddenVisual then
+			displayType = Enum.TransmogOutfitDisplayType.Hidden;
+			if transmogID == 0 then
+				--0 isn't a usable appearance id for Hidden, resolve a real one
+				transmogID = addon.TransmogUtil.GetHiddenSourceIDForSlot(invSlotID) or transmogID;
+			end
+		else
+			displayType = Enum.TransmogOutfitDisplayType.Assigned;
+		end
+
+		if slot and transmogID then
+			C_TransmogOutfitInfo.SetPendingTransmog(slot, transmogType, option, transmogID, displayType);
+		end
+	end
+
+	local function ApplySnapshotToPending(itemTransmogInfoList)
+		for invSlotID, transmogInfo in ipairs(itemTransmogInfoList) do
+			if not IgnoredInvSlots[invSlotID] then
+				local transmogID = transmogInfo.appearanceID;
+
+				if invSlotID == 3 then
+					local secondaryAppearanceID = transmogInfo.secondaryAppearanceID;
+					SetPendingFromSlot(invSlotID, SHOULDER_RIGHT, transmogID);
+					if secondaryAppearanceID == 0 then
+						--0 means the left shoulder was never set independently, mirror the right
+						secondaryAppearanceID = transmogID;
+					end
+					SetPendingFromSlot(invSlotID, Enum.TransmogOutfitSlot.ShoulderLeft, secondaryAppearanceID);
+				else
+					local slot = C_TransmogOutfitInfo.GetTransmogOutfitSlotFromInventorySlot(invSlotID - 1);
+					local illusionID, weaponOption;
+					if invSlotID == 16 or invSlotID == 17 then
+						--Weapon slots must be written under the equipped weapon's option, or SetPendingTransmog silently does nothing
+						illusionID = transmogInfo.illusionID;
+						weaponOption = slot and C_TransmogOutfitInfo.GetEquippedSlotOptionFromTransmogSlot(slot);
+					end
+					SetPendingFromSlot(invSlotID, slot, transmogID, illusionID, weaponOption);
+				end
+			end
+		end
+	end
+	EL.ApplySnapshotToPending = ApplySnapshotToPending;
+
+	local function RestoreShoulderSecondaryState(enabled)
+		if enabled ~= nil then
+			C_TransmogOutfitInfo.SetSecondarySlotState(SHOULDER_RIGHT, enabled);
+		end
+	end
+	EL.RestoreShoulderSecondaryState = RestoreShoulderSecondaryState;
+
+	local function ForceWeaponSlotWidgetRebuild()
+		--Toggling shoulder secondary state forces a weapon slot widget rebuild, working around a Blizzard display
+		--bug where the widget caches the wrong option (e.g. 1H for an equipped 2H) on first build. Must run first.
+		local liveSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
+		C_TransmogOutfitInfo.SetSecondarySlotState(SHOULDER_RIGHT, not liveSecondary);
+		C_TransmogOutfitInfo.SetSecondarySlotState(SHOULDER_RIGHT, liveSecondary);
+	end
+	EL.ForceWeaponSlotWidgetRebuild = ForceWeaponSlotWidgetRebuild;
+end
+
+
+do
+	local SNAPSHOT_EVENTS = {
+		"VIEWED_TRANSMOG_OUTFIT_SLOT_REFRESH", -- Queue a transmog change
+	};
+
+	--Piggyback on Blizzard's /customset format to store this as a string instead of a nested table.
+	--CreateCustomSetSlashCommand ignores the mixin methods on the list entries, so passing it straight through works.
+	local function SerializeSnapshot(itemTransmogInfoList)
+		local createFunc = TransmogUtil and TransmogUtil.CreateCustomSetSlashCommand;
+		local slashCommand = createFunc and createFunc(itemTransmogInfoList);
+		--Strip the "/customset " prefix, ParseCustomSetSlashCommand only wants the "v1 ..." part
+		return slashCommand and slashCommand:match("^/customset (.+)$");
+	end
+
+	local function DeserializeSnapshot(str)
+		local parseFunc = TransmogUtil and TransmogUtil.ParseCustomSetSlashCommand;
+		return parseFunc and parseFunc(str);
+	end
+
+	local function SaveSnapshotToDB()
+		if not PlumberDB_PC then return end;
+
+		if EL.pendingSnapshot then
+			PlumberDB_PC.TransmogRestorePending = {
+				snapshot = SerializeSnapshot(EL.pendingSnapshot),
+				shoulderSecondary = EL.pendingShoulderSecondary,
+			};
+		else
+			PlumberDB_PC.TransmogRestorePending = nil;
+		end
+	end
+	EL.SaveSnapshotToDB = SaveSnapshotToDB;
+
+	local function LoadSnapshotFromDB()
+		local saved = PlumberDB_PC and PlumberDB_PC.TransmogRestorePending;
+		if saved then
+			if type(saved.snapshot) == "string" then
+				EL.pendingSnapshot = DeserializeSnapshot(saved.snapshot);
+			else
+				--Older Plumber versions stored a plain table snapshot directly
+				EL.pendingSnapshot = saved.snapshot;
+			end
+			EL.pendingShoulderSecondary = saved.shoulderSecondary;
+		end
+	end
+	EL.LoadSnapshotFromDB = LoadSnapshotFromDB;
+
+	local function CaptureSnapshot()
+		if not EL.enabled then return end;
+
+		if not C_TransmogOutfitInfo.HasPendingOutfitTransmogs() then
+			EL.pendingSnapshot = nil;
+			EL.pendingShoulderSecondary = nil;
+		else
+			EL.pendingSnapshot = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
+			EL.pendingShoulderSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
+		end
+
+		SaveSnapshotToDB();
+	end
+
+	local function RestorePendingSnapshot()
+		--Clear early, a write below can retrigger CaptureSnapshot mid-call
+		local snapshot = EL.pendingSnapshot;
+		local shoulderSecondary = EL.pendingShoulderSecondary;
+		EL.pendingSnapshot = nil;
+		EL.pendingShoulderSecondary = nil;
+		EL.SaveSnapshotToDB();
+
+		EL.ForceWeaponSlotWidgetRebuild();
+
+		--Must run before ApplySnapshotToPending, toggling this after would wipe the left shoulder's pending value
+		EL.RestoreShoulderSecondaryState(shoulderSecondary);
+		EL.ApplySnapshotToPending(snapshot);
+		--If we ever want to notify the user their outfit was restored, this is where it'd happen.
+	end
+
+	local function OnSnapshotEvent()
+		if not EL.enabled then return end;
+
+		CaptureSnapshot();
+	end
+
+	local function TransmogFrame_OnShow()
+		if not EL.enabled then return end;
+
+		for _, event in ipairs(SNAPSHOT_EVENTS) do
+			EL:RegisterEvent(event);
+		end
+
+		if EL.pendingSnapshot then
+			RestorePendingSnapshot();
+		end
+	end
+
+	local function TransmogFrame_OnHide()
+		EL:UnregisterAllEvents();
+	end
+
+	local function SnapshotFrame_OnLoad()
+		if EL.snapshotHooked then return end;
+		EL.snapshotHooked = true;
+
+		EL:SetScript("OnEvent", OnSnapshotEvent);
+		TransmogFrame:HookScript("OnShow", TransmogFrame_OnShow);
+		TransmogFrame:HookScript("OnHide", TransmogFrame_OnHide);
+
+		if TransmogFrame:IsShown() then
+			TransmogFrame_OnShow();
+		end
+	end
+	EL.SnapshotFrame_OnLoad = SnapshotFrame_OnLoad;
+end
+
+
+do
+	local function EnableModule(state)
+		if state and not EL.enabled then
+			EL.enabled = true;
+			EL.LoadSnapshotFromDB();
+			addon.CallbackRegistry:RegisterAddOnLoadedCallback("Blizzard_Transmog", EL.SnapshotFrame_OnLoad);
+		elseif (not state) and EL.enabled then
+			EL.enabled = nil;
+			addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_Transmog", EL.SnapshotFrame_OnLoad);
+			EL.pendingSnapshot = nil;
+			EL.pendingShoulderSecondary = nil;
+			EL.SaveSnapshotToDB();
+		end
+	end
+
+	local moduleData = {
+		name = L["ModuleName TransmogRestorePending"],
+		dbKey = "TransmogRaestorePending",
+		description = L["ModuleDescription TransmogRestorePending"],
+		toggleFunc = EnableModule,
+		moduleAddedTime = 1788399603,
+		categoryKeys = {"Collection"},
+	};
+
+	addon.ControlCenter:AddModule(moduleData);
+end

--- a/Modules/TransmogUtil.lua
+++ b/Modules/TransmogUtil.lua
@@ -62,6 +62,7 @@ local function GetHiddenSourceIDForSlot(slotID)
 	end
 end
 TransmogUtil.GetAppearanceSources = GetAppearanceSources;
+TransmogUtil.GetHiddenSourceIDForSlot = GetHiddenSourceIDForSlot;
 
 
 local function PopupateInfoListWithHiddenVisuals(itemTransmogInfoList)

--- a/Plumber.toc
+++ b/Plumber.toc
@@ -86,6 +86,7 @@ Modules\BreakTime.xml
 Modules\CatalystUI.lua
 Modules\HuntTable.lua
 Modules\PreyQuestSuperTrack.lua
+Modules\TransmogRestorePending.lua
 
 
 #Modules\MerchantUI\MerchantUI.xml


### PR DESCRIPTION

https://github.com/user-attachments/assets/79e1953e-5a9f-4fd7-b63f-ac69c3ba81ad

*A video is a thousand pictures, said someone ever.. Surely.*

This adds a new module, called `Transmog UI: Restore Pending Changes`.

It basically saves the pending changes from the Transmog window, and re-applies them on the next window open.
This persists through sessions as it is saved to the CharDB.

This is to avoid those 30 minute mog sessions where someone shares a quest and killed your window, or you accidentally opening window and this closing the Transmog window.

A second video demonstrating the full weapon options saving (including illusions and sheathing):

https://github.com/user-attachments/assets/ad9e8e4b-5342-493e-8c0e-d6586a07af13
