### PR TITLE
Transmog Restore: Restore last selected outfit + keep changes between outfits + situations

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -95,6 +95,13 @@ stds.wow = {
 		"WardrobeItemModelMixin",
 		"WardrobeItemsCollectionSlotButtonMixin",
 
+		C_TransmogOutfitInfo = {
+			fields = {
+				"ClearAllPendingSituations",
+				"ClearAllPendingTransmogs",
+			},
+		},
+
 		GameTooltip = {
 			fields = {
 				"factionID",
@@ -446,6 +453,7 @@ stds.wow = {
 		"SocketInventoryItem",
 		"SplashFrame",
 		"SpellIsTargeting",
+		"StaticPopup_Hide",
 		"StaticPopup_Show",
 		"StopSound",
 		"Storyline_DialogChoicesScrollFrame",
@@ -1285,18 +1293,24 @@ stds.wow = {
 				"GetCurrentlyViewedOutfitID",
 				"GetEquippedSlotOptionFromTransmogSlot",
 				"GetOutfitInfo",
+				"GetOutfitSituation",
+				"GetOutfitSituationsEnabled",
 				"GetOutfitsInfo",
 				"GetSecondarySlotState",
 				"GetTransmogOutfitSlotFromInventorySlot",
+				"GetUISituationCategoriesAndOptions",
 				"GetViewedOutfitSlotInfo",
 				"GetWeaponOptionsForSlot",
+				"HasPendingOutfitSituations",
 				"HasPendingOutfitTransmogs",
 				"IsEquippedGearOutfitDisplayed",
 				"IsLockedOutfit",
 				"PickupOutfit",
+				"SetOutfitSituationsEnabled",
 				"SetPendingTransmog",
 				"SetPendingTransmogSheatheCategory",
 				"SetSecondarySlotState",
+				"UpdatePendingSituation",
 			},
 		},
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -99,6 +99,7 @@ stds.wow = {
 			fields = {
 				"ClearAllPendingSituations",
 				"ClearAllPendingTransmogs",
+				"CommitAndApplyAllPending",
 			},
 		},
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1280,8 +1280,11 @@ stds.wow = {
 		C_TransmogOutfitInfo = {
 			fields = {
 				"ChangeToOutfit",
+				"ChangeViewedOutfit",
 				"GetActiveOutfitID",
+				"GetCurrentlyViewedOutfitID",
 				"GetEquippedSlotOptionFromTransmogSlot",
+				"GetOutfitInfo",
 				"GetOutfitsInfo",
 				"GetSecondarySlotState",
 				"GetTransmogOutfitSlotFromInventorySlot",

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -472,17 +472,18 @@ do
 	end
 
 	local function OnSituationsChanged()
-		--SetOutfitSituationsEnabled/UpdatePendingSituation below re-fire this event, guard against the recursion.
+		--Restores below re-fire this event, guard against the recursion.
 		if isHandlingSituationsChanged then return; end
 		isHandlingSituationsChanged = true;
 
 		local wipedTransmogs = (EL.PendingSnapshot or EL.PendingWeaponOptions) and not PendingStillApplied();
-		local wipedSituations = EL.PendingSituations and not C_TransmogOutfitInfo.HasPendingOutfitSituations();
+		--Situations only need fighting back when the outfit just changed, not on a same-outfit toggle.
+		local isOutfitSwitch = EL.LastViewedOutfitID and EL.LastViewedOutfitID ~= C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID();
+		local wipedSituations = isOutfitSwitch and EL.PendingSituations and not C_TransmogOutfitInfo.HasPendingOutfitSituations();
 
 		if not (wipedTransmogs or wipedSituations) then
 			CapturePending();
 		else
-			--Blizzard's own Situations auto-switch can silently discard pending edits, fight back with what we had.
 			isRestoringPending = true;
 			if wipedTransmogs then
 				ApplyPendingSnapshot(EL.PendingSnapshot, EL.PendingSlots, EL.PendingShoulderSecondary, EL.PendingWeaponOptions);

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -184,6 +184,7 @@ do
 				snapshot = SerializeSnapshot(EL.pendingSnapshot),
 				shoulderSecondary = EL.pendingShoulderSecondary,
 				weaponOptions = EL.pendingWeaponOptions,
+				outfitID = EL.pendingOutfitID,
 			};
 		else
 			PlumberDB_PC.TransmogRestorePending = nil;
@@ -202,6 +203,7 @@ do
 			end
 			EL.pendingShoulderSecondary = saved.shoulderSecondary;
 			EL.pendingWeaponOptions = saved.weaponOptions;
+			EL.pendingOutfitID = saved.outfitID;
 		end
 	end
 
@@ -212,13 +214,25 @@ do
 			EL.pendingSnapshot = nil;
 			EL.pendingShoulderSecondary = nil;
 			EL.pendingWeaponOptions = nil;
+			EL.pendingOutfitID = nil;
 		else
 			EL.pendingSnapshot = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
 			EL.pendingShoulderSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
 			EL.pendingWeaponOptions = EL.CaptureWeaponOptionsPending();
+			--Frame reopens on the active outfit, so remember which one was actually being edited.
+			EL.pendingOutfitID = C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID();
 		end
 
 		SaveSnapshotToDB();
+	end
+
+	local function RestoreViewedOutfit(outfitID)
+		if outfitID == nil then return end;
+		if outfitID == C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID() then return end;
+		--0 is the equipped-gear view (always valid); other outfits may have been deleted since capture.
+		if outfitID == 0 or C_TransmogOutfitInfo.GetOutfitInfo(outfitID) then
+			C_TransmogOutfitInfo.ChangeViewedOutfit(outfitID);
+		end
 	end
 
 	local function RestorePendingSnapshot()
@@ -226,10 +240,15 @@ do
 		local snapshot = EL.pendingSnapshot;
 		local shoulderSecondary = EL.pendingShoulderSecondary;
 		local weaponOptions = EL.pendingWeaponOptions;
+		local outfitID = EL.pendingOutfitID;
 		EL.pendingSnapshot = nil;
 		EL.pendingShoulderSecondary = nil;
 		EL.pendingWeaponOptions = nil;
+		EL.pendingOutfitID = nil;
 		EL.SaveSnapshotToDB();
+
+		--Must run first, since Blizzard's OnShow forces the active outfit and switching outfits wipes pending changes.
+		RestoreViewedOutfit(outfitID);
 
 		EL.ForceWeaponSlotWidgetRebuild();
 
@@ -290,6 +309,7 @@ do
 			EL.pendingSnapshot = nil;
 			EL.pendingShoulderSecondary = nil;
 			EL.pendingWeaponOptions = nil;
+			EL.pendingOutfitID = nil;
 			EL.SaveSnapshotToDB();
 		end
 	end

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -154,12 +154,58 @@ do
 		C_TransmogOutfitInfo.SetSecondarySlotState(SHOULDER_RIGHT, not liveSecondary);
 		C_TransmogOutfitInfo.SetSecondarySlotState(SHOULDER_RIGHT, liveSecondary);
 	end
+
+	--Save all situations-related data (4 id fields) in one string, making it a simple per line row for SavedVariables.
+	local function SituationOptionKey(option)
+		return string.format("%d,%d,%d,%d", option.situationID, option.specID, option.loadoutID, option.equipmentSetID);
+	end
+
+	function EL.CaptureSituationsPending()
+		local situationsPending = {
+			enabled = C_TransmogOutfitInfo.GetOutfitSituationsEnabled(),
+			options = {},
+		};
+
+		local situationsData = C_TransmogOutfitInfo.GetUISituationCategoriesAndOptions();
+		for _, categoryData in ipairs(situationsData or {}) do
+			for _, groupData in ipairs(categoryData.groupData) do
+				for _, optionData in ipairs(groupData.optionData) do
+					local option = optionData.option;
+					situationsPending.options[SituationOptionKey(option)] = C_TransmogOutfitInfo.GetOutfitSituation(option);
+				end
+			end
+		end
+
+		return situationsPending;
+	end
+
+	function EL.RestoreSituationsPending(situationsPending)
+		if not situationsPending then return end;
+
+		C_TransmogOutfitInfo.SetOutfitSituationsEnabled(situationsPending.enabled);
+
+		--Fetch options live so a deleted loadout or equipment set is skipped, not restored.
+		local situationsData = C_TransmogOutfitInfo.GetUISituationCategoriesAndOptions();
+		for _, categoryData in ipairs(situationsData or {}) do
+			for _, groupData in ipairs(categoryData.groupData) do
+				for _, optionData in ipairs(groupData.optionData) do
+					local option = optionData.option;
+					local value = situationsPending.options[SituationOptionKey(option)];
+					if value ~= nil then
+						C_TransmogOutfitInfo.UpdatePendingSituation(option, value);
+					end
+				end
+			end
+		end
+	end
 end
 
 
 do
-	local SNAPSHOT_EVENTS = {
+	local TRACKED_EVENTS = {
 		"VIEWED_TRANSMOG_OUTFIT_SLOT_REFRESH", -- Queue a transmog change
+		"VIEWED_TRANSMOG_OUTFIT_CHANGED", -- Outfit slot switched
+		"VIEWED_TRANSMOG_OUTFIT_SITUATIONS_CHANGED", -- Queue a situation change
 	};
 
 	--Piggyback on Blizzard's /customset format to store this as a string instead of a nested table.
@@ -176,23 +222,26 @@ do
 		return parseFunc and parseFunc(str);
 	end
 
-	local function SaveSnapshotToDB()
+	local function SavePendingToDB()
 		if not PlumberDB_PC then return end;
 
-		if EL.pendingSnapshot then
+		if EL.pendingSnapshot or EL.pendingSituations then
+			--SerializeSnapshot expects a real list, only call it when there's actually a snapshot
+			local snapshot = EL.pendingSnapshot and SerializeSnapshot(EL.pendingSnapshot);
 			PlumberDB_PC.TransmogRestorePending = {
-				snapshot = SerializeSnapshot(EL.pendingSnapshot),
+				snapshot = snapshot,
 				shoulderSecondary = EL.pendingShoulderSecondary,
 				weaponOptions = EL.pendingWeaponOptions,
+				situations = EL.pendingSituations,
 				outfitID = EL.pendingOutfitID,
 			};
 		else
 			PlumberDB_PC.TransmogRestorePending = nil;
 		end
 	end
-	EL.SaveSnapshotToDB = SaveSnapshotToDB;
+	EL.SavePendingToDB = SavePendingToDB;
 
-	function EL.LoadSnapshotFromDB()
+	function EL.LoadPendingFromDB()
 		local saved = PlumberDB_PC and PlumberDB_PC.TransmogRestorePending;
 		if saved then
 			if type(saved.snapshot) == "string" then
@@ -203,27 +252,32 @@ do
 			end
 			EL.pendingShoulderSecondary = saved.shoulderSecondary;
 			EL.pendingWeaponOptions = saved.weaponOptions;
+			EL.pendingSituations = saved.situations;
 			EL.pendingOutfitID = saved.outfitID;
 		end
 	end
 
-	local function CaptureSnapshot()
+	local function CapturePending()
 		if not EL.enabled then return end;
 
-		if not C_TransmogOutfitInfo.HasPendingOutfitTransmogs() then
-			EL.pendingSnapshot = nil;
-			EL.pendingShoulderSecondary = nil;
-			EL.pendingWeaponOptions = nil;
-			EL.pendingOutfitID = nil;
-		else
+		local hasTransmogsPending = C_TransmogOutfitInfo.HasPendingOutfitTransmogs();
+		if hasTransmogsPending then
 			EL.pendingSnapshot = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
 			EL.pendingShoulderSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
 			EL.pendingWeaponOptions = EL.CaptureWeaponOptionsPending();
-			--Frame reopens on the active outfit, so remember which one was actually being edited.
-			EL.pendingOutfitID = C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID();
+		else
+			EL.pendingSnapshot = nil;
+			EL.pendingShoulderSecondary = nil;
+			EL.pendingWeaponOptions = nil;
 		end
 
-		SaveSnapshotToDB();
+		local hasSituationsPending = C_TransmogOutfitInfo.HasPendingOutfitSituations();
+		EL.pendingSituations = hasSituationsPending and EL.CaptureSituationsPending() or nil;
+
+		--Frame reopens on the active outfit, so remember which one was actually being edited.
+		EL.pendingOutfitID = (hasTransmogsPending or hasSituationsPending) and C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID() or nil;
+
+		SavePendingToDB();
 	end
 
 	local function RestoreViewedOutfit(outfitID)
@@ -235,20 +289,16 @@ do
 		end
 	end
 
-	local function RestorePendingSnapshot()
-		--Clear early, a write below can retrigger CaptureSnapshot mid-call
-		local snapshot = EL.pendingSnapshot;
-		local shoulderSecondary = EL.pendingShoulderSecondary;
-		local weaponOptions = EL.pendingWeaponOptions;
-		local outfitID = EL.pendingOutfitID;
+	local function ClearPendingState()
 		EL.pendingSnapshot = nil;
 		EL.pendingShoulderSecondary = nil;
 		EL.pendingWeaponOptions = nil;
+		EL.pendingSituations = nil;
 		EL.pendingOutfitID = nil;
-		EL.SaveSnapshotToDB();
+	end
 
-		--Must run first, since Blizzard's OnShow forces the active outfit and switching outfits wipes pending changes.
-		RestoreViewedOutfit(outfitID);
+	local function ApplyPendingSnapshot(snapshot, shoulderSecondary, weaponOptions)
+		if not snapshot then return end;
 
 		EL.ForceWeaponSlotWidgetRebuild();
 
@@ -257,24 +307,87 @@ do
 		EL.ApplySnapshotToPending(snapshot);
 		--Must run after ApplySnapshotToPending, setting a weapon's appearance resets its sheathe category to Default
 		EL.RestoreWeaponOptionsPending(weaponOptions);
+	end
+
+	local function RestoreAllPending()
+		--Clear early, a write below can retrigger CapturePending mid-call
+		local snapshot = EL.pendingSnapshot;
+		local shoulderSecondary = EL.pendingShoulderSecondary;
+		local weaponOptions = EL.pendingWeaponOptions;
+		local situations = EL.pendingSituations;
+		local outfitID = EL.pendingOutfitID;
+		ClearPendingState();
+		EL.SavePendingToDB();
+
+		--Must run first, since Blizzard's OnShow forces the active outfit and switching outfits wipes pending changes.
+		RestoreViewedOutfit(outfitID);
+		ApplyPendingSnapshot(snapshot, shoulderSecondary, weaponOptions);
+		EL.RestoreSituationsPending(situations);
 		--If we ever want to notify the user their outfit was restored, this is where it'd happen.
 	end
 
-	local function OnSnapshotEvent()
+	local function ReapplyPendingOnOutfitSwitch()
+		--Nothing pending, or this switch is our own RestoreViewedOutfit call above, already handled.
+		if not EL.pendingSnapshot and not EL.pendingSituations then return end;
+
+		local snapshot = EL.pendingSnapshot;
+		local shoulderSecondary = EL.pendingShoulderSecondary;
+		local weaponOptions = EL.pendingWeaponOptions;
+		local situations = EL.pendingSituations;
+		ClearPendingState();
+		EL.SavePendingToDB();
+
+		--The user already landed on the outfit they picked, just replay the edits onto it.
+		ApplyPendingSnapshot(snapshot, shoulderSecondary, weaponOptions);
+		EL.RestoreSituationsPending(situations);
+	end
+
+	local isHandlingSituationsChanged = false;
+
+	local function OnSituationsChanged()
+		--SetOutfitSituationsEnabled/UpdatePendingSituation below re-fire this event, guard against the recursion.
+		if isHandlingSituationsChanged then return end;
+		isHandlingSituationsChanged = true;
+
+		local wipedTransmogs = EL.pendingSnapshot and not C_TransmogOutfitInfo.HasPendingOutfitTransmogs();
+		local wipedSituations = EL.pendingSituations and not C_TransmogOutfitInfo.HasPendingOutfitSituations();
+
+		if not (wipedTransmogs or wipedSituations) then
+			CapturePending();
+		else
+			--Blizzard's own Situations auto-switch can silently discard pending edits, fight back with what we had.
+			if wipedTransmogs then
+				ApplyPendingSnapshot(EL.pendingSnapshot, EL.pendingShoulderSecondary, EL.pendingWeaponOptions);
+			end
+			if wipedSituations then
+				EL.RestoreSituationsPending(EL.pendingSituations);
+			end
+		end
+
+		isHandlingSituationsChanged = false;
+	end
+
+	local function OnTrackedEvent(_, event)
 		if not EL.enabled then return end;
 
-		CaptureSnapshot();
+		if event == "VIEWED_TRANSMOG_OUTFIT_CHANGED" then
+			ReapplyPendingOnOutfitSwitch();
+		elseif event == "VIEWED_TRANSMOG_OUTFIT_SITUATIONS_CHANGED" then
+			OnSituationsChanged();
+		else
+			CapturePending();
+		end
 	end
 
 	local function TransmogFrame_OnShow()
 		if not EL.enabled then return end;
 
-		for _, event in ipairs(SNAPSHOT_EVENTS) do
+		for _, event in ipairs(TRACKED_EVENTS) do
 			EL:RegisterEvent(event);
 		end
 
-		if EL.pendingSnapshot then
-			RestorePendingSnapshot();
+		if EL.pendingSnapshot or EL.pendingSituations then
+			RestoreAllPending();
 		end
 	end
 
@@ -282,13 +395,53 @@ do
 		EL:UnregisterAllEvents();
 	end
 
+	local function OnStaticPopupShown(which, _, _, data)
+		if which ~= "TRANSMOG_PENDING_CHANGES" or not EL.enabled then return end;
+		local hasPending = C_TransmogOutfitInfo.HasPendingOutfitTransmogs() or C_TransmogOutfitInfo.HasPendingOutfitSituations();
+		if not hasPending then return end;
+
+		--Both appearance and situation pending changes now survive an outfit switch, so this warning is stale.
+		StaticPopup_Hide(which, data);
+		if data and data.confirmCallback then
+			data.confirmCallback();
+		end
+	end
+
+	--Only treat this as an intentional Undo while the frame is open, otherwise OnSituationsChanged
+	--would fight back against it and recurse into a stack overflow (oops!). Blizzard also runs these on
+	--every close (OnHide), and treating that as intentional too would break restore-on-reopen.
+	local function HookExplicitClears()
+		local originalClearTransmogs = C_TransmogOutfitInfo.ClearAllPendingTransmogs;
+		C_TransmogOutfitInfo.ClearAllPendingTransmogs = function(...)
+			if TransmogFrame:IsShown() then
+				EL.pendingSnapshot = nil;
+				EL.pendingShoulderSecondary = nil;
+				EL.pendingWeaponOptions = nil;
+				EL.SavePendingToDB();
+			end
+			return originalClearTransmogs(...);
+		end;
+
+		local originalClearSituations = C_TransmogOutfitInfo.ClearAllPendingSituations;
+		C_TransmogOutfitInfo.ClearAllPendingSituations = function(...)
+			if TransmogFrame:IsShown() then
+				EL.pendingSituations = nil;
+				EL.SavePendingToDB();
+			end
+			return originalClearSituations(...);
+		end;
+	end
+
 	function EL.SnapshotFrame_OnLoad()
 		if EL.snapshotHooked then return end;
 		EL.snapshotHooked = true;
 
-		EL:SetScript("OnEvent", OnSnapshotEvent);
+		EL:SetScript("OnEvent", OnTrackedEvent);
 		TransmogFrame:HookScript("OnShow", TransmogFrame_OnShow);
 		TransmogFrame:HookScript("OnHide", TransmogFrame_OnHide);
+		-- If we decide not to disable/skip the popup, comment/remove this hooksecurefunc below.
+		hooksecurefunc("StaticPopup_Show", OnStaticPopupShown);
+		HookExplicitClears();
 
 		if TransmogFrame:IsShown() then
 			TransmogFrame_OnShow();
@@ -301,7 +454,7 @@ do
 	local function EnableModule(state)
 		if state and not EL.enabled then
 			EL.enabled = true;
-			EL.LoadSnapshotFromDB();
+			EL.LoadPendingFromDB();
 			addon.CallbackRegistry:RegisterAddOnLoadedCallback("Blizzard_Transmog", EL.SnapshotFrame_OnLoad);
 		elseif (not state) and EL.enabled then
 			EL.enabled = nil;
@@ -309,8 +462,9 @@ do
 			EL.pendingSnapshot = nil;
 			EL.pendingShoulderSecondary = nil;
 			EL.pendingWeaponOptions = nil;
+			EL.pendingSituations = nil;
 			EL.pendingOutfitID = nil;
-			EL.SaveSnapshotToDB();
+			EL.SavePendingToDB();
 		end
 	end
 

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -504,6 +504,15 @@ do
 			local isSeparated = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
 			EL.ReapplyShoulderAppearance(EL.LiveShoulderInfo, isSeparated);
 		end
+
+		--Re-merging shoulders clears the left shoulder slot selection, which then defaults to head.
+		--Re-select the right shoulder instead.
+		if not TransmogFrame.CharacterPreview:GetSelectedSlotData() then
+			local rightSlotFrame = TransmogFrame.CharacterPreview:GetSlotFrame(SHOULDER_RIGHT, Enum.TransmogType.Appearance);
+			if rightSlotFrame then
+				TransmogFrame:SelectSlot(rightSlotFrame, true);
+			end
+		end
 	end
 
 	local function OnTrackedEvent(_, event)

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -401,6 +401,27 @@ do
 		end
 	end
 
+	local function GetShoulderSlotFrame(isSeparated)
+		local slot = isSeparated and Enum.TransmogOutfitSlot.ShoulderLeft or SHOULDER_RIGHT;
+		return TransmogFrame.CharacterPreview:GetSlotFrame(slot, Enum.TransmogType.Appearance);
+	end
+
+	--Slot frames get released and recreated on every outfit switch, so track the slot enum instead of the frame.
+	local function OnSlotSelected(_, slotFrame)
+		local transmogLocation = slotFrame and slotFrame.slotData and slotFrame.slotData.transmogLocation;
+		EL.LastSelectedSlot = transmogLocation and transmogLocation:GetSlot();
+	end
+
+	--Always reselects explicitly, Blizzard can clear the left shoulder before our pending restore re-separates it.
+	local function ReselectShoulderOnOutfitSwitch()
+		if EL.LastSelectedSlot ~= Enum.TransmogOutfitSlot.ShoulderLeft then return; end
+
+		local slotFrame = GetShoulderSlotFrame(true) or GetShoulderSlotFrame(false);
+		if slotFrame then
+			TransmogFrame:SelectSlot(slotFrame, true);
+		end
+	end
+
 	local function ApplyPendingSnapshot(snapshot, pendingSlots, shoulderSecondary, weaponOptions)
 		if not snapshot then return; end
 
@@ -428,13 +449,14 @@ do
 	local function ReapplyPendingOnOutfitSwitch()
 		--Tracked even when nothing's pending, so reopening later still lands back on the outfit last selected/viewed.
 		EL.LastViewedOutfitID = C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID();
-		if not EL.PendingSnapshot and not EL.PendingSituations then return; end
-
-		isRestoringPending = true;
-		--The user already landed on the outfit they picked, just replay the edits onto it.
-		ApplyPendingSnapshot(EL.PendingSnapshot, EL.PendingSlots, EL.PendingShoulderSecondary, EL.PendingWeaponOptions);
-		EL.RestoreSituationsPending(EL.PendingSituations);
-		isRestoringPending = false;
+		if EL.PendingSnapshot or EL.PendingSituations then
+			isRestoringPending = true;
+			--The user already landed on the outfit they picked, just replay the edits onto it.
+			ApplyPendingSnapshot(EL.PendingSnapshot, EL.PendingSlots, EL.PendingShoulderSecondary, EL.PendingWeaponOptions);
+			EL.RestoreSituationsPending(EL.PendingSituations);
+			isRestoringPending = false;
+		end
+		ReselectShoulderOnOutfitSwitch();
 	end
 
 	local isHandlingSituationsChanged = false;
@@ -508,7 +530,7 @@ do
 		--Re-merging shoulders clears the left shoulder slot selection, which then defaults to head.
 		--Re-select the right shoulder instead.
 		if not TransmogFrame.CharacterPreview:GetSelectedSlotData() then
-			local rightSlotFrame = TransmogFrame.CharacterPreview:GetSlotFrame(SHOULDER_RIGHT, Enum.TransmogType.Appearance);
+			local rightSlotFrame = GetShoulderSlotFrame(false);
 			if rightSlotFrame then
 				TransmogFrame:SelectSlot(rightSlotFrame, true);
 			end
@@ -590,6 +612,7 @@ do
 		TransmogFrame:HookScript("OnHide", TransmogFrame_OnHide);
 		-- If we decide not to disable/skip the popup, comment/remove this hooksecurefunc below.
 		hooksecurefunc("StaticPopup_Show", OnStaticPopupShown);
+		hooksecurefunc(TransmogFrame, "SelectSlot", OnSlotSelected);
 		HookExplicitClears();
 
 		if TransmogFrame:IsShown() then

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -9,6 +9,12 @@ local WEAPON_SLOTS = {
 	[17] = Enum.TransmogOutfitSlot.WeaponOffHand,
 };
 
+--True if two appearance snapshots match.
+local function SameAppearance(liveInfo, recordedInfo)
+	return liveInfo.appearanceID == recordedInfo.appearanceID
+		and liveInfo.secondaryAppearanceID == recordedInfo.secondaryAppearanceID;
+end
+
 
 do
 	local IgnoredInvSlots = {
@@ -51,9 +57,11 @@ do
 		end
 	end
 
-	function EL.ApplySnapshotToPending(itemTransmogInfoList)
+	--Only replays the tracked pendingSlots, not the whole outfit.
+	--Always writes, since right after switching outfits the character preview hasn't caught up yet.
+	function EL.ApplySnapshotToPending(itemTransmogInfoList, pendingSlots)
 		for invSlotID, transmogInfo in ipairs(itemTransmogInfoList) do
-			if not IgnoredInvSlots[invSlotID] then
+			if pendingSlots[invSlotID] then
 				local transmogID = transmogInfo.appearanceID;
 
 				if invSlotID == 3 then
@@ -72,26 +80,77 @@ do
 		end
 	end
 
+	local function SlotHasPending(slot)
+		local info = C_TransmogOutfitInfo.GetViewedOutfitSlotInfo(slot, Enum.TransmogType.Appearance, Enum.TransmogOutfitSlotOption.None);
+		return info and info.hasPending;
+	end
+
+	--Which invSlotIDs have an unsaved change.
+	--A slot stays tracked while its value still matches what we last set, even once Blizzard stops calling it pending.
+	function EL.CapturePendingSlots(liveList, previousSnapshot, previousSlots)
+		local pendingSlots = {};
+		for invSlotID = 1, 19 do
+			if not IgnoredInvSlots[invSlotID] then
+				local hasPending;
+				if invSlotID == 3 then
+					--Either shoulder counts, the left one is its own slot only while separate shoulders are on
+					hasPending = SlotHasPending(SHOULDER_RIGHT) or SlotHasPending(Enum.TransmogOutfitSlot.ShoulderLeft);
+				else
+					local slot = C_TransmogOutfitInfo.GetTransmogOutfitSlotFromInventorySlot(invSlotID - 1);
+					hasPending = slot and SlotHasPending(slot);
+				end
+
+				if hasPending then
+					pendingSlots[invSlotID] = true;
+				elseif previousSlots and previousSlots[invSlotID] then
+					local liveInfo = liveList[invSlotID];
+					local recordedInfo = previousSnapshot and previousSnapshot[invSlotID];
+					if liveInfo and recordedInfo and SameAppearance(liveInfo, recordedInfo) then
+						pendingSlots[invSlotID] = true;
+					end
+				end
+			end
+		end
+		return pendingSlots;
+	end
+
 	function EL.RestoreShoulderSecondaryState(enabled)
 		if enabled ~= nil then
 			C_TransmogOutfitInfo.SetSecondarySlotState(SHOULDER_RIGHT, enabled);
 		end
 	end
 
-	--Records are {invSlotID, weaponOption, transmogID, illusionID, sheatheCategory}, false marks a field as not captured
-	local function CaptureWeaponOptionRecord(invSlotID, slot, weaponOption)
+	local function FindPreviousWeaponOption(previousWeaponOptions, invSlotID, weaponOption)
+		for _, record in ipairs(previousWeaponOptions or {}) do
+			if record[1] == invSlotID and record[2] == weaponOption then
+				return record;
+			end
+		end
+	end
+
+	--Records are {invSlotID, weaponOption, transmogID, illusionID, sheatheCategory}, false marks a field as not captured.
+	--previous keeps a value tracked the same way EL.CapturePendingSlots does.
+	local function CaptureWeaponOptionRecord(invSlotID, slot, weaponOption, previous)
 		local transmogID, illusionID, sheatheCategory;
 
-		--hasPending means unsaved, not just currently equipped or already saved
 		local appearanceInfo = C_TransmogOutfitInfo.GetViewedOutfitSlotInfo(slot, Enum.TransmogType.Appearance, weaponOption);
-		if appearanceInfo and appearanceInfo.hasPending then
-			transmogID = appearanceInfo.transmogID;
-			sheatheCategory = appearanceInfo.sheatheCategory;
+		if appearanceInfo then
+			if appearanceInfo.hasPending then
+				transmogID = appearanceInfo.transmogID;
+				sheatheCategory = appearanceInfo.sheatheCategory;
+			elseif previous and previous[3] and appearanceInfo.transmogID == previous[3] then
+				transmogID = previous[3];
+				sheatheCategory = appearanceInfo.sheatheCategory;
+			end
 		end
 
 		local illusionInfo = C_TransmogOutfitInfo.GetViewedOutfitSlotInfo(slot, Enum.TransmogType.Illusion, weaponOption);
-		if illusionInfo and illusionInfo.hasPending then
-			illusionID = illusionInfo.transmogID;
+		if illusionInfo then
+			if illusionInfo.hasPending then
+				illusionID = illusionInfo.transmogID;
+			elseif previous and previous[4] and illusionInfo.transmogID == previous[4] then
+				illusionID = previous[4];
+			end
 		end
 
 		if transmogID or illusionID then
@@ -100,12 +159,13 @@ do
 	end
 
 	--Shared so the same capture logic runs for both weaponOptionsInfo and artifactOptionsInfo without duplicating it
-	local function CaptureOptionsInfoList(weaponOptionsPending, invSlotID, slot, optionsInfo)
+	local function CaptureOptionsInfoList(weaponOptionsPending, previousWeaponOptions, invSlotID, slot, optionsInfo)
 		if not optionsInfo then return weaponOptionsPending; end
 
 		for _, optionInfo in ipairs(optionsInfo) do
 			if optionInfo.enabled then
-				local record = CaptureWeaponOptionRecord(invSlotID, slot, optionInfo.weaponOption);
+				local previous = FindPreviousWeaponOption(previousWeaponOptions, invSlotID, optionInfo.weaponOption);
+				local record = CaptureWeaponOptionRecord(invSlotID, slot, optionInfo.weaponOption, previous);
 				if record then
 					weaponOptionsPending = weaponOptionsPending or {};
 					table.insert(weaponOptionsPending, record);
@@ -116,13 +176,13 @@ do
 		return weaponOptionsPending;
 	end
 
-	function EL.CaptureWeaponOptionsPending()
+	function EL.CaptureWeaponOptionsPending(previousWeaponOptions)
 		local weaponOptionsPending;
 		for invSlotID, slot in pairs(WEAPON_SLOTS) do
 			--Artifact spec options use separate enum values, so they never collide with the weapon options here
 			local weaponOptionsInfo, artifactOptionsInfo = C_TransmogOutfitInfo.GetWeaponOptionsForSlot(slot);
-			weaponOptionsPending = CaptureOptionsInfoList(weaponOptionsPending, invSlotID, slot, weaponOptionsInfo);
-			weaponOptionsPending = CaptureOptionsInfoList(weaponOptionsPending, invSlotID, slot, artifactOptionsInfo);
+			weaponOptionsPending = CaptureOptionsInfoList(weaponOptionsPending, previousWeaponOptions, invSlotID, slot, weaponOptionsInfo);
+			weaponOptionsPending = CaptureOptionsInfoList(weaponOptionsPending, previousWeaponOptions, invSlotID, slot, artifactOptionsInfo);
 		end
 		return weaponOptionsPending;
 	end
@@ -223,8 +283,32 @@ do
 		return parseFunc and parseFunc(str);
 	end
 
+	--EL.PendingSlots is a set of invSlotIDs, saved and loaded as a simple comma-joined list.
+	local function SerializePendingSlots(pendingSlots)
+		local list = {};
+		for invSlotID in pairs(pendingSlots) do
+			table.insert(list, invSlotID);
+		end
+		if #list == 0 then return nil; end
+		table.sort(list);
+		return table.concat(list, ",");
+	end
+
+	local function DeserializePendingSlots(str)
+		local pendingSlots = {};
+		if str then
+			for token in str:gmatch("[^,]+") do
+				pendingSlots[tonumber(token)] = true;
+			end
+		end
+		return pendingSlots;
+	end
+
 	local function SavePendingToDB()
 		if not PlumberDB_PC then return end;
+
+		--Saved on its own, separate from pending edits, so it survives even with nothing pending.
+		PlumberDB_PC.TransmogRestoreLastOutfit = EL.LastViewedOutfitID;
 
 		if EL.PendingSnapshot or EL.PendingSituations then
 			--SerializeSnapshot expects a real list, only call it when there's actually a snapshot
@@ -234,7 +318,7 @@ do
 				shoulderSecondary = EL.PendingShoulderSecondary,
 				weaponOptions = EL.PendingWeaponOptions,
 				situations = EL.PendingSituations,
-				outfitID = EL.PendingOutfitID,
+				pendingSlots = EL.PendingSlots and SerializePendingSlots(EL.PendingSlots),
 			};
 		else
 			PlumberDB_PC.TransmogRestorePending = nil;
@@ -243,6 +327,8 @@ do
 	EL.SavePendingToDB = SavePendingToDB;
 
 	function EL.LoadPendingFromDB()
+		EL.LastViewedOutfitID = PlumberDB_PC and PlumberDB_PC.TransmogRestoreLastOutfit;
+
 		local saved = PlumberDB_PC and PlumberDB_PC.TransmogRestorePending;
 		if saved then
 			if type(saved.snapshot) == "string" then
@@ -254,29 +340,37 @@ do
 			EL.PendingShoulderSecondary = saved.shoulderSecondary;
 			EL.PendingWeaponOptions = saved.weaponOptions;
 			EL.PendingSituations = saved.situations;
-			EL.PendingOutfitID = saved.outfitID;
+			--Older Plumber versions didn't record this, better to restore nothing than the whole outfit
+			EL.PendingSlots = EL.PendingSnapshot and DeserializePendingSlots(saved.pendingSlots);
 		end
 	end
 
-	local function CapturePending()
-		if not EL.enabled then return end;
+	local isRestoringPending = false;
 
-		local hasTransmogsPending = C_TransmogOutfitInfo.HasPendingOutfitTransmogs();
+	local function CapturePending()
+		if not EL.enabled or isRestoringPending then return end;
+
+		local liveList = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
+		--Tracked even when nothing's pending, so reopening the frame lands back on the outfit last selected/viewed.
+		EL.LastViewedOutfitID = C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID();
+		local pendingSlots = EL.CapturePendingSlots(liveList, EL.PendingSnapshot, EL.PendingSlots);
+		local weaponOptions = EL.CaptureWeaponOptionsPending(EL.PendingWeaponOptions);
+		local hasTransmogsPending = next(pendingSlots) ~= nil or weaponOptions ~= nil;
+
 		if hasTransmogsPending then
-			EL.PendingSnapshot = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
+			EL.PendingSnapshot = liveList;
+			EL.PendingSlots = pendingSlots;
+			EL.PendingWeaponOptions = weaponOptions;
 			EL.PendingShoulderSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
-			EL.PendingWeaponOptions = EL.CaptureWeaponOptionsPending();
 		else
 			EL.PendingSnapshot = nil;
-			EL.PendingShoulderSecondary = nil;
+			EL.PendingSlots = nil;
 			EL.PendingWeaponOptions = nil;
+			EL.PendingShoulderSecondary = nil;
 		end
 
 		local hasSituationsPending = C_TransmogOutfitInfo.HasPendingOutfitSituations();
 		EL.PendingSituations = hasSituationsPending and EL.CaptureSituationsPending() or nil;
-
-		--Frame reopens on the active outfit, so remember which one was actually being edited.
-		EL.PendingOutfitID = (hasTransmogsPending or hasSituationsPending) and C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID() or nil;
 
 		SavePendingToDB();
 	end
@@ -290,86 +384,105 @@ do
 		end
 	end
 
-	local function ClearPendingState()
-		EL.PendingSnapshot = nil;
-		EL.PendingShoulderSecondary = nil;
-		EL.PendingWeaponOptions = nil;
-		EL.PendingSituations = nil;
-		EL.PendingOutfitID = nil;
-	end
-
-	local function ApplyPendingSnapshot(snapshot, shoulderSecondary, weaponOptions)
+	local function ApplyPendingSnapshot(snapshot, pendingSlots, shoulderSecondary, weaponOptions)
 		if not snapshot then return; end
 
 		EL.ForceWeaponSlotWidgetRebuild();
 
 		--Must run before ApplySnapshotToPending, toggling this after would wipe the left shoulder's pending value
 		EL.RestoreShoulderSecondaryState(shoulderSecondary);
-		EL.ApplySnapshotToPending(snapshot);
+		EL.ApplySnapshotToPending(snapshot, pendingSlots or {});
 		--Must run after ApplySnapshotToPending, setting a weapon's appearance resets its sheathe category to Default
 		EL.RestoreWeaponOptionsPending(weaponOptions);
 	end
 
 	local function RestoreAllPending()
-		--Clear early, a write below can retrigger CapturePending mid-call
-		local snapshot = EL.PendingSnapshot;
-		local shoulderSecondary = EL.PendingShoulderSecondary;
-		local weaponOptions = EL.PendingWeaponOptions;
-		local situations = EL.PendingSituations;
-		local outfitID = EL.PendingOutfitID;
-		ClearPendingState();
-		EL.SavePendingToDB();
-
+		--Nothing is cleared first, the carry-forward check needs the old values while replaying.
+		--isRestoringPending blocks our own writes from being treated as new edits until the real one lands.
+		isRestoringPending = true;
 		--Must run first, since Blizzard's OnShow forces the active outfit and switching outfits wipes pending changes.
-		RestoreViewedOutfit(outfitID);
-		ApplyPendingSnapshot(snapshot, shoulderSecondary, weaponOptions);
-		EL.RestoreSituationsPending(situations);
+		RestoreViewedOutfit(EL.LastViewedOutfitID);
+		ApplyPendingSnapshot(EL.PendingSnapshot, EL.PendingSlots, EL.PendingShoulderSecondary, EL.PendingWeaponOptions);
+		EL.RestoreSituationsPending(EL.PendingSituations);
+		isRestoringPending = false;
 		--If we ever want to notify the user their outfit was restored, this is where it'd happen.
 	end
 
 	local function ReapplyPendingOnOutfitSwitch()
-		--Nothing pending, or this switch is our own RestoreViewedOutfit call above, already handled.
+		--Tracked even when nothing's pending, so reopening later still lands back on the outfit last selected/viewed.
+		EL.LastViewedOutfitID = C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID();
 		if not EL.PendingSnapshot and not EL.PendingSituations then return; end
 
-		local snapshot = EL.PendingSnapshot;
-		local shoulderSecondary = EL.PendingShoulderSecondary;
-		local weaponOptions = EL.PendingWeaponOptions;
-		local situations = EL.PendingSituations;
-		ClearPendingState();
-		EL.SavePendingToDB();
-
+		isRestoringPending = true;
 		--The user already landed on the outfit they picked, just replay the edits onto it.
-		ApplyPendingSnapshot(snapshot, shoulderSecondary, weaponOptions);
-		EL.RestoreSituationsPending(situations);
+		ApplyPendingSnapshot(EL.PendingSnapshot, EL.PendingSlots, EL.PendingShoulderSecondary, EL.PendingWeaponOptions);
+		EL.RestoreSituationsPending(EL.PendingSituations);
+		isRestoringPending = false;
 	end
 
 	local isHandlingSituationsChanged = false;
+
+	--HasPendingOutfitTransmogs reads false once a tracked slot just happens to match its outfit.
+	--So the wipe check below compares actual values instead of trusting that flag.
+	local function PendingStillApplied()
+		if EL.PendingSnapshot and EL.PendingSlots then
+			local liveList = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
+			for invSlotID in pairs(EL.PendingSlots) do
+				local liveInfo = liveList[invSlotID];
+				local recordedInfo = EL.PendingSnapshot[invSlotID];
+				if not (liveInfo and recordedInfo and SameAppearance(liveInfo, recordedInfo)) then
+					return false;
+				end
+			end
+		end
+
+		if EL.PendingWeaponOptions then
+			for _, record in ipairs(EL.PendingWeaponOptions) do
+				local invSlotID, weaponOption, transmogID, illusionID = record[1], record[2], record[3], record[4];
+				local slot = WEAPON_SLOTS[invSlotID];
+				if transmogID then
+					local info = C_TransmogOutfitInfo.GetViewedOutfitSlotInfo(slot, Enum.TransmogType.Appearance, weaponOption);
+					if not (info and info.transmogID == transmogID) then return false; end
+				end
+				if illusionID then
+					local info = C_TransmogOutfitInfo.GetViewedOutfitSlotInfo(slot, Enum.TransmogType.Illusion, weaponOption);
+					if not (info and info.transmogID == illusionID) then return false; end
+				end
+			end
+		end
+
+		return true;
+	end
 
 	local function OnSituationsChanged()
 		--SetOutfitSituationsEnabled/UpdatePendingSituation below re-fire this event, guard against the recursion.
 		if isHandlingSituationsChanged then return; end
 		isHandlingSituationsChanged = true;
 
-		local wipedTransmogs = EL.PendingSnapshot and not C_TransmogOutfitInfo.HasPendingOutfitTransmogs();
+		local wipedTransmogs = (EL.PendingSnapshot or EL.PendingWeaponOptions) and not PendingStillApplied();
 		local wipedSituations = EL.PendingSituations and not C_TransmogOutfitInfo.HasPendingOutfitSituations();
 
 		if not (wipedTransmogs or wipedSituations) then
 			CapturePending();
 		else
 			--Blizzard's own Situations auto-switch can silently discard pending edits, fight back with what we had.
+			isRestoringPending = true;
 			if wipedTransmogs then
-				ApplyPendingSnapshot(EL.PendingSnapshot, EL.PendingShoulderSecondary, EL.PendingWeaponOptions);
+				ApplyPendingSnapshot(EL.PendingSnapshot, EL.PendingSlots, EL.PendingShoulderSecondary, EL.PendingWeaponOptions);
 			end
 			if wipedSituations then
 				EL.RestoreSituationsPending(EL.PendingSituations);
 			end
+			isRestoringPending = false;
 		end
 
 		isHandlingSituationsChanged = false;
 	end
 
 	local function OnTrackedEvent(_, event)
-		if not EL.enabled then return end;
+		--Our own writes fire these same events, and so can Blizzard's close sequence before OnHide unregisters us.
+		--A stray capture in either case would look like everything just got reverted.
+		if not EL.enabled or isRestoringPending or not TransmogFrame:IsShown() then return end;
 
 		if event == "VIEWED_TRANSMOG_OUTFIT_CHANGED" then
 			ReapplyPendingOnOutfitSwitch();
@@ -384,10 +497,9 @@ do
 		if not EL.enabled then return end;
 
 		API.RegisterFrameForEvents(EL, TRACKED_EVENTS);
-
-		if EL.PendingSnapshot or EL.PendingSituations then
-			RestoreAllPending();
-		end
+		--Always restores the last-viewed outfit, whether or not anything is pending.
+		--RestoreAllPending's own pieces already safely do nothing when there's nothing to reapply.
+		RestoreAllPending();
 	end
 
 	local function TransmogFrame_OnHide()
@@ -406,14 +518,14 @@ do
 		end
 	end
 
-	--Only treat this as an intentional Undo while the frame is open, otherwise OnSituationsChanged
-	--would fight back against it and recurse into a stack overflow (oops!). Blizzard also runs these on
-	--every close (OnHide), and treating that as intentional too would break restore-on-reopen.
+	--Only treated as a real Undo while the frame is open, otherwise OnSituationsChanged fights back into a stack overflow (oops!).
+	--Blizzard also calls these on every close, so treating that the same way would break restore-on-reopen.
 	local function HookExplicitClears()
 		local originalClearTransmogs = C_TransmogOutfitInfo.ClearAllPendingTransmogs;
 		C_TransmogOutfitInfo.ClearAllPendingTransmogs = function(...)
 			if TransmogFrame:IsShown() then
 				EL.PendingSnapshot = nil;
+				EL.PendingSlots = nil;
 				EL.PendingShoulderSecondary = nil;
 				EL.PendingWeaponOptions = nil;
 				EL.SavePendingToDB();
@@ -459,10 +571,11 @@ do
 			EL.enabled = nil;
 			addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_Transmog", EL.SnapshotFrame_OnLoad);
 			EL.PendingSnapshot = nil;
+			EL.PendingSlots = nil;
 			EL.PendingShoulderSecondary = nil;
 			EL.PendingWeaponOptions = nil;
 			EL.PendingSituations = nil;
-			EL.PendingOutfitID = nil;
+			EL.LastViewedOutfitID = nil;
 			EL.SavePendingToDB();
 		end
 	end

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -226,15 +226,15 @@ do
 	local function SavePendingToDB()
 		if not PlumberDB_PC then return end;
 
-		if EL.pendingSnapshot or EL.pendingSituations then
+		if EL.PendingSnapshot or EL.PendingSituations then
 			--SerializeSnapshot expects a real list, only call it when there's actually a snapshot
-			local snapshot = EL.pendingSnapshot and SerializeSnapshot(EL.pendingSnapshot);
+			local snapshot = EL.PendingSnapshot and SerializeSnapshot(EL.PendingSnapshot);
 			PlumberDB_PC.TransmogRestorePending = {
 				snapshot = snapshot,
-				shoulderSecondary = EL.pendingShoulderSecondary,
-				weaponOptions = EL.pendingWeaponOptions,
-				situations = EL.pendingSituations,
-				outfitID = EL.pendingOutfitID,
+				shoulderSecondary = EL.PendingShoulderSecondary,
+				weaponOptions = EL.PendingWeaponOptions,
+				situations = EL.PendingSituations,
+				outfitID = EL.PendingOutfitID,
 			};
 		else
 			PlumberDB_PC.TransmogRestorePending = nil;
@@ -246,15 +246,15 @@ do
 		local saved = PlumberDB_PC and PlumberDB_PC.TransmogRestorePending;
 		if saved then
 			if type(saved.snapshot) == "string" then
-				EL.pendingSnapshot = DeserializeSnapshot(saved.snapshot);
+				EL.PendingSnapshot = DeserializeSnapshot(saved.snapshot);
 			else
 				--Older Plumber versions stored a plain table snapshot directly
-				EL.pendingSnapshot = saved.snapshot;
+				EL.PendingSnapshot = saved.snapshot;
 			end
-			EL.pendingShoulderSecondary = saved.shoulderSecondary;
-			EL.pendingWeaponOptions = saved.weaponOptions;
-			EL.pendingSituations = saved.situations;
-			EL.pendingOutfitID = saved.outfitID;
+			EL.PendingShoulderSecondary = saved.shoulderSecondary;
+			EL.PendingWeaponOptions = saved.weaponOptions;
+			EL.PendingSituations = saved.situations;
+			EL.PendingOutfitID = saved.outfitID;
 		end
 	end
 
@@ -263,20 +263,20 @@ do
 
 		local hasTransmogsPending = C_TransmogOutfitInfo.HasPendingOutfitTransmogs();
 		if hasTransmogsPending then
-			EL.pendingSnapshot = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
-			EL.pendingShoulderSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
-			EL.pendingWeaponOptions = EL.CaptureWeaponOptionsPending();
+			EL.PendingSnapshot = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
+			EL.PendingShoulderSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
+			EL.PendingWeaponOptions = EL.CaptureWeaponOptionsPending();
 		else
-			EL.pendingSnapshot = nil;
-			EL.pendingShoulderSecondary = nil;
-			EL.pendingWeaponOptions = nil;
+			EL.PendingSnapshot = nil;
+			EL.PendingShoulderSecondary = nil;
+			EL.PendingWeaponOptions = nil;
 		end
 
 		local hasSituationsPending = C_TransmogOutfitInfo.HasPendingOutfitSituations();
-		EL.pendingSituations = hasSituationsPending and EL.CaptureSituationsPending() or nil;
+		EL.PendingSituations = hasSituationsPending and EL.CaptureSituationsPending() or nil;
 
 		--Frame reopens on the active outfit, so remember which one was actually being edited.
-		EL.pendingOutfitID = (hasTransmogsPending or hasSituationsPending) and C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID() or nil;
+		EL.PendingOutfitID = (hasTransmogsPending or hasSituationsPending) and C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID() or nil;
 
 		SavePendingToDB();
 	end
@@ -291,11 +291,11 @@ do
 	end
 
 	local function ClearPendingState()
-		EL.pendingSnapshot = nil;
-		EL.pendingShoulderSecondary = nil;
-		EL.pendingWeaponOptions = nil;
-		EL.pendingSituations = nil;
-		EL.pendingOutfitID = nil;
+		EL.PendingSnapshot = nil;
+		EL.PendingShoulderSecondary = nil;
+		EL.PendingWeaponOptions = nil;
+		EL.PendingSituations = nil;
+		EL.PendingOutfitID = nil;
 	end
 
 	local function ApplyPendingSnapshot(snapshot, shoulderSecondary, weaponOptions)
@@ -312,11 +312,11 @@ do
 
 	local function RestoreAllPending()
 		--Clear early, a write below can retrigger CapturePending mid-call
-		local snapshot = EL.pendingSnapshot;
-		local shoulderSecondary = EL.pendingShoulderSecondary;
-		local weaponOptions = EL.pendingWeaponOptions;
-		local situations = EL.pendingSituations;
-		local outfitID = EL.pendingOutfitID;
+		local snapshot = EL.PendingSnapshot;
+		local shoulderSecondary = EL.PendingShoulderSecondary;
+		local weaponOptions = EL.PendingWeaponOptions;
+		local situations = EL.PendingSituations;
+		local outfitID = EL.PendingOutfitID;
 		ClearPendingState();
 		EL.SavePendingToDB();
 
@@ -329,12 +329,12 @@ do
 
 	local function ReapplyPendingOnOutfitSwitch()
 		--Nothing pending, or this switch is our own RestoreViewedOutfit call above, already handled.
-		if not EL.pendingSnapshot and not EL.pendingSituations then return; end
+		if not EL.PendingSnapshot and not EL.PendingSituations then return; end
 
-		local snapshot = EL.pendingSnapshot;
-		local shoulderSecondary = EL.pendingShoulderSecondary;
-		local weaponOptions = EL.pendingWeaponOptions;
-		local situations = EL.pendingSituations;
+		local snapshot = EL.PendingSnapshot;
+		local shoulderSecondary = EL.PendingShoulderSecondary;
+		local weaponOptions = EL.PendingWeaponOptions;
+		local situations = EL.PendingSituations;
 		ClearPendingState();
 		EL.SavePendingToDB();
 
@@ -350,18 +350,18 @@ do
 		if isHandlingSituationsChanged then return; end
 		isHandlingSituationsChanged = true;
 
-		local wipedTransmogs = EL.pendingSnapshot and not C_TransmogOutfitInfo.HasPendingOutfitTransmogs();
-		local wipedSituations = EL.pendingSituations and not C_TransmogOutfitInfo.HasPendingOutfitSituations();
+		local wipedTransmogs = EL.PendingSnapshot and not C_TransmogOutfitInfo.HasPendingOutfitTransmogs();
+		local wipedSituations = EL.PendingSituations and not C_TransmogOutfitInfo.HasPendingOutfitSituations();
 
 		if not (wipedTransmogs or wipedSituations) then
 			CapturePending();
 		else
 			--Blizzard's own Situations auto-switch can silently discard pending edits, fight back with what we had.
 			if wipedTransmogs then
-				ApplyPendingSnapshot(EL.pendingSnapshot, EL.pendingShoulderSecondary, EL.pendingWeaponOptions);
+				ApplyPendingSnapshot(EL.PendingSnapshot, EL.PendingShoulderSecondary, EL.PendingWeaponOptions);
 			end
 			if wipedSituations then
-				EL.RestoreSituationsPending(EL.pendingSituations);
+				EL.RestoreSituationsPending(EL.PendingSituations);
 			end
 		end
 
@@ -385,7 +385,7 @@ do
 
 		API.RegisterFrameForEvents(EL, TRACKED_EVENTS);
 
-		if EL.pendingSnapshot or EL.pendingSituations then
+		if EL.PendingSnapshot or EL.PendingSituations then
 			RestoreAllPending();
 		end
 	end
@@ -413,9 +413,9 @@ do
 		local originalClearTransmogs = C_TransmogOutfitInfo.ClearAllPendingTransmogs;
 		C_TransmogOutfitInfo.ClearAllPendingTransmogs = function(...)
 			if TransmogFrame:IsShown() then
-				EL.pendingSnapshot = nil;
-				EL.pendingShoulderSecondary = nil;
-				EL.pendingWeaponOptions = nil;
+				EL.PendingSnapshot = nil;
+				EL.PendingShoulderSecondary = nil;
+				EL.PendingWeaponOptions = nil;
 				EL.SavePendingToDB();
 			end
 			return originalClearTransmogs(...);
@@ -424,7 +424,7 @@ do
 		local originalClearSituations = C_TransmogOutfitInfo.ClearAllPendingSituations;
 		C_TransmogOutfitInfo.ClearAllPendingSituations = function(...)
 			if TransmogFrame:IsShown() then
-				EL.pendingSituations = nil;
+				EL.PendingSituations = nil;
 				EL.SavePendingToDB();
 			end
 			return originalClearSituations(...);
@@ -458,11 +458,11 @@ do
 		elseif (not state) and EL.enabled then
 			EL.enabled = nil;
 			addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_Transmog", EL.SnapshotFrame_OnLoad);
-			EL.pendingSnapshot = nil;
-			EL.pendingShoulderSecondary = nil;
-			EL.pendingWeaponOptions = nil;
-			EL.pendingSituations = nil;
-			EL.pendingOutfitID = nil;
+			EL.PendingSnapshot = nil;
+			EL.PendingShoulderSecondary = nil;
+			EL.PendingWeaponOptions = nil;
+			EL.PendingSituations = nil;
+			EL.PendingOutfitID = nil;
 			EL.SavePendingToDB();
 		end
 	end

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -601,6 +601,20 @@ do
 			end
 			return originalClearSituations(...);
 		end;
+
+		--A save commits pending changes permanently, our carry-forward tracking would otherwise keep them marked pending forever.
+		local originalCommitAllPending = C_TransmogOutfitInfo.CommitAndApplyAllPending;
+		C_TransmogOutfitInfo.CommitAndApplyAllPending = function(...)
+			if TransmogFrame:IsShown() then
+				EL.PendingSnapshot = nil;
+				EL.PendingSlots = nil;
+				EL.PendingShoulderSecondary = nil;
+				EL.PendingWeaponOptions = nil;
+				EL.PendingSituations = nil;
+				EL.SavePendingToDB();
+			end
+			return originalCommitAllPending(...);
+		end;
 	end
 
 	function EL.SnapshotFrame_OnLoad()

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -1,5 +1,6 @@
 local _, addon = ...
 local L = addon.L;
+local API = addon.API;
 
 local EL = CreateFrame("Frame");
 local SHOULDER_RIGHT = Enum.TransmogOutfitSlot.ShoulderRight;
@@ -382,9 +383,7 @@ do
 	local function TransmogFrame_OnShow()
 		if not EL.enabled then return end;
 
-		for _, event in ipairs(TRACKED_EVENTS) do
-			EL:RegisterEvent(event);
-		end
+		API.RegisterFrameForEvents(EL, TRACKED_EVENTS);
 
 		if EL.pendingSnapshot or EL.pendingSituations then
 			RestoreAllPending();
@@ -392,7 +391,7 @@ do
 	end
 
 	local function TransmogFrame_OnHide()
-		EL:UnregisterAllEvents();
+		API.UnregisterFrameForEvents(EL, TRACKED_EVENTS);
 	end
 
 	local function OnStaticPopupShown(which, _, _, data)

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -101,7 +101,7 @@ do
 
 	--Shared so the same capture logic runs for both weaponOptionsInfo and artifactOptionsInfo without duplicating it
 	local function CaptureOptionsInfoList(weaponOptionsPending, invSlotID, slot, optionsInfo)
-		if not optionsInfo then return weaponOptionsPending end;
+		if not optionsInfo then return weaponOptionsPending; end
 
 		for _, optionInfo in ipairs(optionsInfo) do
 			if optionInfo.enabled then
@@ -128,7 +128,7 @@ do
 	end
 
 	function EL.RestoreWeaponOptionsPending(weaponOptionsPending)
-		if not weaponOptionsPending then return end;
+		if not weaponOptionsPending then return; end
 
 		for _, record in ipairs(weaponOptionsPending) do
 			local invSlotID, weaponOption, transmogID, illusionID, sheatheCategory = record[1], record[2], record[3], record[4], record[5];
@@ -181,7 +181,7 @@ do
 	end
 
 	function EL.RestoreSituationsPending(situationsPending)
-		if not situationsPending then return end;
+		if not situationsPending then return; end
 
 		C_TransmogOutfitInfo.SetOutfitSituationsEnabled(situationsPending.enabled);
 
@@ -282,8 +282,8 @@ do
 	end
 
 	local function RestoreViewedOutfit(outfitID)
-		if outfitID == nil then return end;
-		if outfitID == C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID() then return end;
+		if outfitID == nil then return; end
+		if outfitID == C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID() then return; end
 		--0 is the equipped-gear view (always valid); other outfits may have been deleted since capture.
 		if outfitID == 0 or C_TransmogOutfitInfo.GetOutfitInfo(outfitID) then
 			C_TransmogOutfitInfo.ChangeViewedOutfit(outfitID);
@@ -299,7 +299,7 @@ do
 	end
 
 	local function ApplyPendingSnapshot(snapshot, shoulderSecondary, weaponOptions)
-		if not snapshot then return end;
+		if not snapshot then return; end
 
 		EL.ForceWeaponSlotWidgetRebuild();
 
@@ -329,7 +329,7 @@ do
 
 	local function ReapplyPendingOnOutfitSwitch()
 		--Nothing pending, or this switch is our own RestoreViewedOutfit call above, already handled.
-		if not EL.pendingSnapshot and not EL.pendingSituations then return end;
+		if not EL.pendingSnapshot and not EL.pendingSituations then return; end
 
 		local snapshot = EL.pendingSnapshot;
 		local shoulderSecondary = EL.pendingShoulderSecondary;
@@ -347,7 +347,7 @@ do
 
 	local function OnSituationsChanged()
 		--SetOutfitSituationsEnabled/UpdatePendingSituation below re-fire this event, guard against the recursion.
-		if isHandlingSituationsChanged then return end;
+		if isHandlingSituationsChanged then return; end
 		isHandlingSituationsChanged = true;
 
 		local wipedTransmogs = EL.pendingSnapshot and not C_TransmogOutfitInfo.HasPendingOutfitTransmogs();
@@ -395,9 +395,9 @@ do
 	end
 
 	local function OnStaticPopupShown(which, _, _, data)
-		if which ~= "TRANSMOG_PENDING_CHANGES" or not EL.enabled then return end;
+		if which ~= "TRANSMOG_PENDING_CHANGES" or not EL.enabled then return; end
 		local hasPending = C_TransmogOutfitInfo.HasPendingOutfitTransmogs() or C_TransmogOutfitInfo.HasPendingOutfitSituations();
-		if not hasPending then return end;
+		if not hasPending then return; end
 
 		--Both appearance and situation pending changes now survive an outfit switch, so this warning is stale.
 		StaticPopup_Hide(which, data);

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -366,7 +366,7 @@ do
 		local liveList = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
 		--Kept even when nothing's pending, so the separate-shoulders fix has a value to fall back to.
 		EL.LiveShoulderInfo = liveList[3];
-		--Tracked even when nothing's pending, so reopening the frame lands back on the outfit last selected/viewed.
+		--Tracked even when nothing's pending, so later checks can tell if the outfit actually changed.
 		EL.LastViewedOutfitID = C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID();
 		local pendingSlots, shoulderSecondary = EL.CapturePendingSlots(liveList, EL.PendingSnapshot, EL.PendingSlots);
 		local weaponOptions = EL.CaptureWeaponOptionsPending(EL.PendingWeaponOptions);
@@ -438,8 +438,10 @@ do
 		--Nothing is cleared first, the carry-forward check needs the old values while replaying.
 		--isRestoringPending blocks our own writes from being treated as new edits until the real one lands.
 		isRestoringPending = true;
-		--Must run first, since Blizzard's OnShow forces the active outfit and switching outfits wipes pending changes.
-		RestoreViewedOutfit(EL.LastViewedOutfitID);
+		--With nothing pending, Blizzard's own default outfit is fine as is.
+		if EL.PendingSnapshot then
+			RestoreViewedOutfit(EL.LastViewedOutfitID);
+		end
 		ApplyPendingSnapshot(EL.PendingSnapshot, EL.PendingSlots, EL.PendingShoulderSecondary, EL.PendingWeaponOptions);
 		EL.RestoreSituationsPending(EL.PendingSituations);
 		isRestoringPending = false;
@@ -447,7 +449,7 @@ do
 	end
 
 	local function ReapplyPendingOnOutfitSwitch()
-		--Tracked even when nothing's pending, so reopening later still lands back on the outfit last selected/viewed.
+		--Tracked even when nothing's pending, so later checks can tell if the outfit actually changed.
 		EL.LastViewedOutfitID = C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID();
 		if EL.PendingSnapshot or EL.PendingSituations then
 			isRestoringPending = true;
@@ -557,8 +559,6 @@ do
 		if not EL.enabled then return end;
 
 		API.RegisterFrameForEvents(EL, TRACKED_EVENTS);
-		--Always restores the last-viewed outfit, whether or not anything is pending.
-		--RestoreAllPending's own pieces already safely do nothing when there's nothing to reapply.
 		RestoreAllPending();
 	end
 

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -57,24 +57,31 @@ do
 		end
 	end
 
+	--Right always wins, left mirrors it while separated unless left was set independently.
+	--Once merged, right and left can share the same slot, so writing left too would override right back.
+	function EL.ReapplyShoulderAppearance(transmogInfo, isSeparated)
+		local transmogID = transmogInfo.appearanceID;
+		SetPendingFromSlot(3, SHOULDER_RIGHT, transmogID);
+		if isSeparated then
+			local secondaryAppearanceID = transmogInfo.secondaryAppearanceID;
+			if secondaryAppearanceID == 0 then
+				--0 means the left shoulder was never set independently, mirror the right
+				secondaryAppearanceID = transmogID;
+			end
+			SetPendingFromSlot(3, Enum.TransmogOutfitSlot.ShoulderLeft, secondaryAppearanceID);
+		end
+	end
+
 	--Only replays the tracked pendingSlots, not the whole outfit.
 	--Always writes, since right after switching outfits the character preview hasn't caught up yet.
 	function EL.ApplySnapshotToPending(itemTransmogInfoList, pendingSlots)
 		for invSlotID, transmogInfo in ipairs(itemTransmogInfoList) do
 			if pendingSlots[invSlotID] then
-				local transmogID = transmogInfo.appearanceID;
-
 				if invSlotID == 3 then
-					local secondaryAppearanceID = transmogInfo.secondaryAppearanceID;
-					SetPendingFromSlot(invSlotID, SHOULDER_RIGHT, transmogID);
-					if secondaryAppearanceID == 0 then
-						--0 means the left shoulder was never set independently, mirror the right
-						secondaryAppearanceID = transmogID;
-					end
-					SetPendingFromSlot(invSlotID, Enum.TransmogOutfitSlot.ShoulderLeft, secondaryAppearanceID);
+					EL.ReapplyShoulderAppearance(transmogInfo, true);
 				else
 					local slot = C_TransmogOutfitInfo.GetTransmogOutfitSlotFromInventorySlot(invSlotID - 1);
-					SetPendingFromSlot(invSlotID, slot, transmogID);
+					SetPendingFromSlot(invSlotID, slot, transmogInfo.appearanceID);
 				end
 			end
 		end
@@ -89,12 +96,17 @@ do
 	--A slot stays tracked while its value still matches what we last set, even once Blizzard stops calling it pending.
 	function EL.CapturePendingSlots(liveList, previousSnapshot, previousSlots)
 		local pendingSlots = {};
+		local shoulderSecondary;
 		for invSlotID = 1, 19 do
 			if not IgnoredInvSlots[invSlotID] then
 				local hasPending;
 				if invSlotID == 3 then
 					--Either shoulder counts, the left one is its own slot only while separate shoulders are on
 					hasPending = SlotHasPending(SHOULDER_RIGHT) or SlotHasPending(Enum.TransmogOutfitSlot.ShoulderLeft);
+					if hasPending then
+						--Only capture when fresh, a switch briefly resets this and reading it then would lose our value
+						shoulderSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
+					end
 				else
 					local slot = C_TransmogOutfitInfo.GetTransmogOutfitSlotFromInventorySlot(invSlotID - 1);
 					hasPending = slot and SlotHasPending(slot);
@@ -111,7 +123,7 @@ do
 				end
 			end
 		end
-		return pendingSlots;
+		return pendingSlots, shoulderSecondary;
 	end
 
 	function EL.RestoreShoulderSecondaryState(enabled)
@@ -267,6 +279,7 @@ do
 		"VIEWED_TRANSMOG_OUTFIT_SLOT_REFRESH", -- Queue a transmog change
 		"VIEWED_TRANSMOG_OUTFIT_CHANGED", -- Outfit slot switched
 		"VIEWED_TRANSMOG_OUTFIT_SITUATIONS_CHANGED", -- Queue a situation change
+		"VIEWED_TRANSMOG_OUTFIT_SECONDARY_SLOTS_CHANGED", -- Separate shoulders toggled
 	};
 
 	--Piggyback on Blizzard's /customset format to store this as a string instead of a nested table.
@@ -351,9 +364,11 @@ do
 		if not EL.enabled or isRestoringPending then return end;
 
 		local liveList = TransmogFrame.CharacterPreview:GetItemTransmogInfoList();
+		--Kept even when nothing's pending, so the separate-shoulders fix has a value to fall back to.
+		EL.LiveShoulderInfo = liveList[3];
 		--Tracked even when nothing's pending, so reopening the frame lands back on the outfit last selected/viewed.
 		EL.LastViewedOutfitID = C_TransmogOutfitInfo.GetCurrentlyViewedOutfitID();
-		local pendingSlots = EL.CapturePendingSlots(liveList, EL.PendingSnapshot, EL.PendingSlots);
+		local pendingSlots, shoulderSecondary = EL.CapturePendingSlots(liveList, EL.PendingSnapshot, EL.PendingSlots);
 		local weaponOptions = EL.CaptureWeaponOptionsPending(EL.PendingWeaponOptions);
 		local hasTransmogsPending = next(pendingSlots) ~= nil or weaponOptions ~= nil;
 
@@ -361,7 +376,9 @@ do
 			EL.PendingSnapshot = liveList;
 			EL.PendingSlots = pendingSlots;
 			EL.PendingWeaponOptions = weaponOptions;
-			EL.PendingShoulderSecondary = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
+			if shoulderSecondary ~= nil then
+				EL.PendingShoulderSecondary = shoulderSecondary;
+			end
 		else
 			EL.PendingSnapshot = nil;
 			EL.PendingSlots = nil;
@@ -479,6 +496,15 @@ do
 		isHandlingSituationsChanged = false;
 	end
 
+	--Blizzard doesn't carry the shoulder appearance across this toggle.
+	--Uses EL.LiveShoulderInfo instead of a fresh read, which could already show the same reset.
+	local function FixShoulderSecondaryToggle()
+		if EL.LiveShoulderInfo then
+			local isSeparated = C_TransmogOutfitInfo.GetSecondarySlotState(SHOULDER_RIGHT);
+			EL.ReapplyShoulderAppearance(EL.LiveShoulderInfo, isSeparated);
+		end
+	end
+
 	local function OnTrackedEvent(_, event)
 		--Our own writes fire these same events, and so can Blizzard's close sequence before OnHide unregisters us.
 		--A stray capture in either case would look like everything just got reverted.
@@ -488,6 +514,8 @@ do
 			ReapplyPendingOnOutfitSwitch();
 		elseif event == "VIEWED_TRANSMOG_OUTFIT_SITUATIONS_CHANGED" then
 			OnSituationsChanged();
+		elseif event == "VIEWED_TRANSMOG_OUTFIT_SECONDARY_SLOTS_CHANGED" then
+			FixShoulderSecondaryToggle();
 		else
 			CapturePending();
 		end


### PR DESCRIPTION
https://github.com/user-attachments/assets/eec953d6-0a87-4cac-b90d-533f2697c536

This PR handles three extra things;
- When TransmogFrame is opened, we restore the last outfit the pending changes were made on.
- When switching between outfits, we keep the pending changes.
- When switching between outfits, we also keep the pending situations.

For those last two, I've optionally added a popup skip, given it is no longer correct if our module is used.
If this is not preferred, it can be removed/commented out.

<img width="371" height="94" alt="2026-09-04_00-19-32-965" src="https://github.com/user-attachments/assets/4bdbf449-fe57-4b13-8053-42001db0785d" />

> [!NOTE]  
> `HookExplicitClears` might be a bit confusing.
> Basically our code can't distinguish between a user clicking "undo all pending changes" vs Blizzard's functions resetting pending changes (due to how TransmogFrame is written).
> 
> In the former we obviously want the user's button press to wipe everything, in the latter we save stuff and block the undo so that they don't wipe our progress.