### PR TITLE
1.9.5 b

### DIFF
--- a/Documentation.lua
+++ b/Documentation.lua
@@ -1,0 +1,15 @@
+--- A documentation for Plumber API and Global Objects.
+--- In case other addon devs want to do something with them like reskinning or changing position, scale.
+
+
+------ Widgets ------
+
+
+--- Name: PlumberInstanceDifficultySelector
+--- File: DifficultySelector.lua
+--- Note: The frame is created right away, but it's not fully loaded until the player approachs a supported instance. When it's fully loaded, it triggers "Plumber.DifficultySelector.OnInit" through WoW's EventRegistry.
+
+
+--- Name: PlumberInstanceDifficultyAnnouncer
+--- File: DifficultySelector.lua
+--- Note: This frame appears briefly on the top of the screen when you enter an instance. Loading is similar to the DifficultySelector above, but it triggers "Plumber.DifficultyAnnouncer.OnInit"

--- a/Initialization.lua
+++ b/Initialization.lua
@@ -1,5 +1,5 @@
-local VERSION_TEXT = "1.9.5";
-local VERSION_DATE = 1788400000;
+local VERSION_TEXT = "1.9.5 b";
+local VERSION_DATE = 1788800000;
 
 
 local addonName, addon = ...

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -785,6 +785,7 @@ L["EditMode Instruction InstanceDifficulty"] = "The frame width is affected by t
 L["Difficulty Locked To Format"] = "The instance is locked to |cffffffff%s|r due to boss kill.";
 L["Difficulty Locked To Current Alert"] = "The instance is locked to this difficulty due to boss kill.";
 L["Shared Difficulty Alert"] = "Defeating a boss will lock the instance to this difficulty.";
+L["Can Only Change Difficulty Via Native UI"] = "This difficulty can only be selected when interacting with the entrance portal.";
 
 
 --TransmogChatCommand

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -754,6 +754,7 @@ L["EditMode Instruction InstanceDifficulty"] = "此窗口的实际宽度由选�
 L["Difficulty Locked To Format"] = "此副本难度被锁定为|cffffffff%s|r，因为你已击败了一个首领。";
 L["Difficulty Locked To Current Alert"] = "此副本难度被锁定为当前难度，因为你已击败了一个首领。";
 L["Shared Difficulty Alert"] = "击败任何一个首领将会使副本锁定至此难度。";
+L["Can Only Change Difficulty Via Native UI"] = "你必须与副本入口交互才能选择此难度。";
 
 
 --TransmogChatCommand

--- a/Modules/ControlCenter/Changelog/enUS.lua
+++ b/Modules/ControlCenter/Changelog/enUS.lua
@@ -10,6 +10,63 @@ local changelogs = addon.ControlCenter.changelogs;
 changelogs[10905] = {
 	{
 		type = "date",
+		versionText = "1.9.5 b",
+		timestamp = 1788800000,
+	},
+
+	{
+		type = "h1",
+		text = L["ModuleName TransmogRaestorePending"],
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Pending changes can now be moved over to another outfit.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Pending situations are also stored now.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Closing the Transmog UI with pending changes and then reopening it will automatically select the outfit you were editing, instead of jumping to the active one.",
+	},
+
+	{
+		type = "br",
+	},
+
+	{
+		type = "h1",
+		text = MISCELLANEOUS,
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "The \"World\" difficulty for The Tidebound Grotto now correctly appears on the Instance Difficulty Selector and the Raids tab in the Expansion Summary UI.",
+	},
+
+	{
+		type = "p",
+		bullet = true,
+		text = "Expansion Summary Minimap Button: You can access Blizzard's Omnium Folio UI from the right-click menu once unlocked.",
+	},
+
+	{
+		type = "br",
+	},
+	{
+		type = "br",
+	},
+
+	{
+		type = "date",
 		versionText = "1.9.5",
 		timestamp = 1788400000,
 	},
@@ -28,7 +85,7 @@ changelogs[10905] = {
 	{
 		type = "p",
 		bullet = true,
-		text = L["ModuleDescription TransmogRaestorePending"],
+		text = "Pending Transmog changes are automatically restored when reopening the window.",
 	},
 
 	{

--- a/Modules/ExpansionLandingPage/API_Encounter.lua
+++ b/Modules/ExpansionLandingPage/API_Encounter.lua
@@ -111,7 +111,7 @@ do  --Derivative of Blizzard_EncounterJournal.lua
 
 		local name = DifficultyUtil.GetDifficultyName(difficultyID);
 		local size = GetEJDifficultySize(difficultyID);
-		if size then
+		if size and difficultyID ~= DifficultyUtil.ID.RaidWorld then
 			return string.format(ENCOUNTER_JOURNAL_DIFF_TEXT, size, name);
 		else
 			return name;

--- a/Modules/ExpansionLandingPage/API_Encounter.lua
+++ b/Modules/ExpansionLandingPage/API_Encounter.lua
@@ -70,6 +70,7 @@ do  --Derivative of Blizzard_EncounterJournal.lua
 		DifficultyUtil.ID.Raid10Heroic,
 		DifficultyUtil.ID.Raid25Normal,
 		DifficultyUtil.ID.Raid25Heroic,
+		DifficultyUtil.ID.RaidWorld,
 		DifficultyUtil.ID.PrimaryRaidLFR,
 		DifficultyUtil.ID.PrimaryRaidNormal,
 		DifficultyUtil.ID.PrimaryRaidHeroic,
@@ -86,6 +87,7 @@ do  --Derivative of Blizzard_EncounterJournal.lua
 		DifficultyUtil.ID.Raid10Heroic,
 		DifficultyUtil.ID.Raid25Normal,
 		DifficultyUtil.ID.Raid25Heroic,
+		DifficultyUtil.ID.RaidWorld,
 		DifficultyUtil.ID.PrimaryRaidNormal,
 		DifficultyUtil.ID.PrimaryRaidHeroic,
 		DifficultyUtil.ID.PrimaryRaidMythic,
@@ -124,7 +126,7 @@ do  --Derivative of Blizzard_EncounterJournal.lua
 		SelectInstanceAndEncounter(journalInstanceID, encounterID);
 
 		for index, difficultyID in ipairs(EJ_DIFFICULTIES) do
-			if EJ_IsValidInstanceDifficulty(difficultyID) then
+			if difficultyID and EJ_IsValidInstanceDifficulty(difficultyID) then
 				local text = GetEJDifficultyString(difficultyID);
 				n = n + 1;
 				tbl[n] = {
@@ -172,7 +174,7 @@ do  --Derivative of Blizzard_EncounterJournal.lua
 		local difficulties = {};
 
 		for index, difficultyID in ipairs(VALID_DIFFUICULTY_OPEN_WORLD) do
-			if EJ_IsValidInstanceDifficulty(difficultyID) then
+			if difficultyID and EJ_IsValidInstanceDifficulty(difficultyID) then
 				local text = GetEJDifficultyString(difficultyID);
 				n = n + 1;
 				difficulties[n] = {

--- a/Modules/ExpansionLandingPage/EncounterData.lua
+++ b/Modules/ExpansionLandingPage/EncounterData.lua
@@ -98,6 +98,8 @@ local EncounterData = {
 
 
 local Difficulties;
+local OverrideDifficulties = {};
+
 if addon.IS_MOP then
 	Difficulties = {
 		DifficultyUtil.ID.RaidLFR,
@@ -112,6 +114,17 @@ else
 		DifficultyUtil.ID.PrimaryRaidNormal,
 		DifficultyUtil.ID.PrimaryRaidHeroic,
 		DifficultyUtil.ID.PrimaryRaidMythic,
+	};
+
+	local Lairs = {
+		DifficultyUtil.ID.RaidWorld,
+		DifficultyUtil.ID.PrimaryRaidNormal,
+		DifficultyUtil.ID.PrimaryRaidHeroic,
+		DifficultyUtil.ID.PrimaryRaidMythic,
+	};
+
+	OverrideDifficulties = {
+		[2987] = Lairs,		-- Nymrissa Wavecaller
 	};
 end
 LandingPageUtil.RaidDifficulties = Difficulties;
@@ -201,8 +214,9 @@ function LandingPageUtil.GetEncounterProgress(instanceID, dungeonEncounterID)
 	--instanceID = mapID
 
 	local progress = {};    --{boolean1, boolean2, ...}
+	local difficulties = OverrideDifficulties[instanceID] or Difficulties;
 
-	for i, difficultyID in ipairs(Difficulties) do
+	for i, difficultyID in ipairs(difficulties) do
 		progress[i] = IsEncounterComplete(instanceID, dungeonEncounterID, difficultyID);
 	end
 
@@ -211,8 +225,9 @@ end
 
 function LandingPageUtil.GetInstanceProgress(instanceID, dungeonEncounterIDs)
 	local consolidatedProgress = {};    --{numComplete1, numComplete2, ...}
+	local difficulties = OverrideDifficulties[instanceID] or Difficulties;
 
-	for i, difficultyID in ipairs(Difficulties) do
+	for i, difficultyID in ipairs(difficulties) do
 		local numComplete = 0;
 		for _, dungeonEncounterID in ipairs(dungeonEncounterIDs) do
 			if IsEncounterComplete(instanceID, dungeonEncounterID, difficultyID) then

--- a/Modules/ExpansionLandingPage/MinimapButton.lua
+++ b/Modules/ExpansionLandingPage/MinimapButton.lua
@@ -14,7 +14,7 @@ local EL = CreateFrame("Frame");
 local DragController = CreateFrame("Frame", nil, UIParent);
 local UIParentContainer = CreateFrame("Frame", nil, UIParent);
 local MiniButton;
-local MenuSchematc;
+local MenuSchematic;
 
 
 local Def = {
@@ -608,9 +608,9 @@ do  --Order Hall, RightClickMenu
 	end
 
 	local function InitMenuSchematic()
-		if MenuSchematc then return end;
+		if MenuSchematic then return end;
 
-		MenuSchematc = {
+		MenuSchematic = {
 			tag = "PlumberLandingButtonMenu",
 			objects = {};
 			onMenuClosedCallback = function()
@@ -620,45 +620,45 @@ do  --Order Hall, RightClickMenu
 		};
 
 		if GetDBBool("LandingButton_SmartExpansion") then
-			table.insert(MenuSchematc.objects, {type = "Button", name = L["Abbr NewExpansionLandingPage"],
+			table.insert(MenuSchematic.objects, {type = "Button", name = L["Abbr NewExpansionLandingPage"],
 				OnClick = function()
 					LandingPageUtil.ToggleUI();
 				end,
 			});
 
-			table.insert(MenuSchematc.objects, {type = "Button", name = JOURNEYS_LABEL,
+			table.insert(MenuSchematic.objects, {type = "Button", name = JOURNEYS_LABEL,
 				OnClick = function()
 					OrderHallUtil.ToggleBlizzardJourneys();
 				end,
 			});
 
-			table.insert(MenuSchematc.objects, {type = "Divider"});
+			table.insert(MenuSchematic.objects, {type = "Divider"});
 		else
 			--Add a button to open the other UI
 			if Options.GetChoice_PrimaryUI() == 2 then
-				table.insert(MenuSchematc.objects, {type = "Button", name = L["Abbr NewExpansionLandingPage"],
+				table.insert(MenuSchematic.objects, {type = "Button", name = L["Abbr NewExpansionLandingPage"],
 					OnClick = function()
 						LandingPageUtil.ToggleUI();
 					end,
 				});
 			else
-				table.insert(MenuSchematc.objects, {type = "Button", name = JOURNEYS_LABEL,
+				table.insert(MenuSchematic.objects, {type = "Button", name = JOURNEYS_LABEL,
 					OnClick = function()
 						OrderHallUtil.ToggleBlizzardJourneys();
 					end,
 				});
 			end
 
-			table.insert(MenuSchematc.objects, {type = "Divider"});
+			table.insert(MenuSchematic.objects, {type = "Divider"});
 		end
 
 		for k, v in ipairs(OrderHallButtons) do
-			table.insert(MenuSchematc.objects, v);
+			table.insert(MenuSchematic.objects, v);
 		end
 
-		table.insert(MenuSchematc.objects, {type = "Divider"});
+		table.insert(MenuSchematic.objects, {type = "Divider"});
 
-		table.insert(MenuSchematc.objects, {type = "Button", name = L["LandingButton Customize"],
+		table.insert(MenuSchematic.objects, {type = "Button", name = L["LandingButton Customize"],
 			OnClick = function()
 				MiniButton:ToggleSettings();
 			end,
@@ -756,7 +756,7 @@ do  --Order Hall, RightClickMenu
 		GameTooltip:Hide();
 		InitMenuSchematic();
 		local contextData = {};
-		local menu = addon.API.ShowBlizzardMenu(self, MenuSchematc, contextData);
+		local menu = addon.API.ShowBlizzardMenu(self, MenuSchematic, contextData);
 		self.shownMenu = menu;
 		menu:ClearAllPoints();
 		menu:SetPoint("TOPLEFT", self, "BOTTOMRIGHT", 0, 4);
@@ -774,7 +774,7 @@ do  --Order Hall, RightClickMenu
 	function ButtonManager.OpenContextMenu(widget)
 		InitMenuSchematic();
 		local contextData = {};
-		local menu = addon.API.ShowBlizzardMenu(widget, MenuSchematc, contextData);
+		local menu = addon.API.ShowBlizzardMenu(widget, MenuSchematic, contextData);
 		menu:ClearAllPoints();
 		menu:SetPoint("TOPLEFT", widget, "BOTTOMRIGHT", 2, -2);
 	end
@@ -1104,7 +1104,7 @@ do  --Button Settings/Customize
 	end
 
 	function ButtonMixin:LoadSettings()
-		MenuSchematc = nil;
+		MenuSchematic = nil;
 
 		self.darkMode = GetDBBool("LandingButton_DarkColor");
 

--- a/Modules/ExpansionLandingPage/MinimapButton.lua
+++ b/Modules/ExpansionLandingPage/MinimapButton.lua
@@ -566,6 +566,18 @@ do  --Order Hall, RightClickMenu
 		return false
 	end
 
+	function OrderHallUtil.ToggleNativeLandingPage()
+		if API.CheckAndDisplayErrorIfInCombat() then return; end
+
+		local f = ExpansionLandingPage;
+		if f:IsShown() then
+			HideUIPanel(f);
+		else
+			f:RefreshExpansionOverlay();
+			ShowUIPanel(f);
+		end
+	end
+
 	local OrderHallButtons = {
 		--WoD Garrison
 		{type = "Button", name = GARRISON_LANDING_PAGE_TITLE, garrTypeID = Enum.GarrisonType.Type_6_0_Garrison},
@@ -654,6 +666,11 @@ do  --Order Hall, RightClickMenu
 
 		for k, v in ipairs(OrderHallButtons) do
 			table.insert(MenuSchematic.objects, v);
+		end
+
+		if C_PlayerInfo.IsExpansionLandingPageUnlockedForPlayer(11) then -- LE_EXPANSION_MIDNIGHT
+			local name = RUNES_OF_POWER .. " (Blizzard)";
+			table.insert(MenuSchematic.objects, {type = "Button", name = name, OnClick = OrderHallUtil.ToggleNativeLandingPage});
 		end
 
 		table.insert(MenuSchematic.objects, {type = "Divider"});

--- a/Modules/GameTooltip_Core.lua
+++ b/Modules/GameTooltip_Core.lua
@@ -305,6 +305,8 @@ do  --GameTooltipManager
 
 			if useLeftTextAsArgument then
 				function handler.ProcessDisplayedData(tooltip)
+					if tooltip.IsEmbedded then return; end -- Disabled for embedded tooltip. Maybe it will fix the taint?
+
 					local tooltipData = tooltip.infoList and tooltip.infoList[1] and tooltip.infoList[1].tooltipData;
 					if tooltipData and tooltipData.type == tooltipDataType then
 						local leftText = tooltipData.lines and tooltipData.lines[1] and tooltipData.lines[1].leftText;
@@ -322,6 +324,8 @@ do  --GameTooltipManager
 				end
 			else
 				function handler.ProcessDisplayedData(tooltip)
+					if tooltip.IsEmbedded then return; end -- Disabled for embedded tooltip. Maybe it will fix the taint?
+
 					local tooltipData = tooltip.infoList and tooltip.infoList[1] and tooltip.infoList[1].tooltipData;
 					if tooltipData and tooltipData.type == tooltipDataType then
 						local arg1 = tooltipData.id;

--- a/Modules/GameTooltip_Core.lua
+++ b/Modules/GameTooltip_Core.lua
@@ -117,6 +117,7 @@ do
 	function HandlerMixin:CallSubModules(tooltip, id, hyperlink)
 		self.altModeState = nil;
 		self.hideGenericAltInstruction = nil;
+		self.anyChange = nil;
 		self.currentTooltip = tooltip;
 
 		for _, m in ipairs(self.modules) do

--- a/Modules/RaidCheck/DataProvider.lua
+++ b/Modules/RaidCheck/DataProvider.lua
@@ -1,5 +1,4 @@
 local _, addon = ...
-local API = addon.API;
 
 
 local RaidCheck = {};
@@ -21,4 +20,10 @@ end
 
 function DataProvider:GetRaidDifficultyID()
 	return GetRaidDifficultyID(), GetLegacyRaidDifficultyID()
+end
+
+-- Some difficulty can only be selected via Blizzard's DifficultyPicker
+-- Such as "World" for Lair "The Tidebound Grotto"
+function DataProvider:IsDiffultySelectable(difficultyID)
+	return difficultyID and difficultyID ~= 250; -- DifficultyUtil.ID.RaidWorld
 end

--- a/Modules/RaidCheck/DifficultySelector.lua
+++ b/Modules/RaidCheck/DifficultySelector.lua
@@ -107,7 +107,10 @@ local function ShowLockoutTooltip(self, instanceName, difficultyName, instanceID
 	end
 
 	if showInstruction then
-		if not CanChangeDifficulty() then
+		if not DataProvider:IsDiffultySelectable(currentDifficultyID) then
+			tooltip:AddLine(" ");
+			tooltip:AddLine(L["Can Only Change Difficulty Via Native UI"], 0.5, 0.5, 0.5, true);
+		elseif not CanChangeDifficulty() then
 			tooltip:AddLine(" ");
 			tooltip:AddLine(L["Cannot Change Difficulty"], 1, 0.125, 0.125, true);
 		end
@@ -819,7 +822,9 @@ do  --SelectorUI
 	end
 
 	function SelectorUI:TrySelectDiffulty(difficultyID)
-		if difficultyID == self.selectedDifficulty then return end;
+		if difficultyID == self.selectedDifficulty then return end
+
+		if not DataProvider:IsDiffultySelectable(difficultyID) then return false; end
 
 		GameTooltip:Hide();
 
@@ -836,7 +841,7 @@ do  --SelectorUI
 			SetDungeonDifficultyID(difficultyID);
 		end
 
-		return true and canChange
+		return true and canChange;
 	end
 
 	function SelectorUI:HighlightButton(button)

--- a/Modules/RaidCheck/DifficultySelector.lua
+++ b/Modules/RaidCheck/DifficultySelector.lua
@@ -13,9 +13,9 @@ local GetInstanceInfoForSelector = API.GetInstanceInfoForSelector;    --See Expa
 local GetInstanceEncounters = API.GetInstanceEncounters;
 
 
-local DifficultyAnnouncer = CreateFrame("Frame", nil, UIParent, "PlumberPropagateMouseTemplate");    --Show difficulty when entering the instance
+local DifficultyAnnouncer = CreateFrame("Frame", "PlumberInstanceDifficultyAnnouncer", UIParent, "PlumberPropagateMouseTemplate");    --Show difficulty when entering the instance
 RaidCheck.DifficultyAnnouncer = DifficultyAnnouncer;
-local SelectorUI = CreateFrame("Frame", nil, UIParent);             --Show difficulty selector at the entrance
+local SelectorUI = CreateFrame("Frame", "PlumberInstanceDifficultySelector", UIParent);             --Show difficulty selector at the entrance
 RaidCheck.SelectorUI = SelectorUI;
 DifficultyAnnouncer:Hide();
 SelectorUI:Hide();
@@ -588,6 +588,8 @@ do  --SelectorUI
 		self:SetScript("OnEvent", self.OnEvent);
 
 		LoadFramePosition();
+
+		EventRegistry:TriggerEvent("Plumber.DifficultySelector.OnInit", self);
 	end
 
 	function SelectorUI:OnShow()
@@ -968,6 +970,8 @@ do  --DifficultyAnnouncer
 		self:SetScript("OnMouseDown", self.OnMouseDown);
 
 		LoadFramePosition();
+
+		EventRegistry:TriggerEvent("Plumber.DifficultyAnnouncer.OnInit", self);
 	end
 
 	function DifficultyAnnouncer:Enable(state)

--- a/Modules/RaidCheck/DifficultySelector.lua
+++ b/Modules/RaidCheck/DifficultySelector.lua
@@ -824,9 +824,9 @@ do  --SelectorUI
 	end
 
 	function SelectorUI:TrySelectDiffulty(difficultyID)
-		if difficultyID == self.selectedDifficulty then return end
+		if difficultyID == self.selectedDifficulty then return; end
 
-		if not DataProvider:IsDiffultySelectable(difficultyID) then return false; end
+		if not DataProvider:IsDiffultySelectable(difficultyID) then return; end
 
 		GameTooltip:Hide();
 
@@ -843,7 +843,7 @@ do  --SelectorUI
 			SetDungeonDifficultyID(difficultyID);
 		end
 
-		return true and canChange;
+		return canChange;
 	end
 
 	function SelectorUI:HighlightButton(button)

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -767,7 +767,7 @@ do
 		dbKey = "TransmogRaestorePending",
 		description = L["ModuleDescription TransmogRaestorePending"],
 		toggleFunc = EnableModule,
-		moduleAddedTime = 1788400000,
+		moduleAddedTime = 1788800000,
 		categoryKeys = {"Collection"},
 		consultant = 2,
 	};

--- a/Plumber.toc
+++ b/Plumber.toc
@@ -1,6 +1,6 @@
 ## X-Flavor: retail
 ## X-Expansion: TWW
-## Interface: 120007, 120100
+## Interface: 120100, 120105
 ## Version: 1.9.5
 
 ## Title: Plumber


### PR DESCRIPTION
- The "World" difficulty for The Tidebound Grotto now correctly appears on the Instance Difficulty Selector and the Raids tab in the Expansion Summary UI.

- **Expansion Summary Minimap Button:** You can access Blizzard's Omnium Folio UI from the right-click menu once unlocked. #483 

- Attempted to fix a tooltip taint. As a result, our tooltip modules will skip EmbeddedTooltip. #493 

- The two frames created by Plumber Instance Difficulty Selector now have global names: `PlumberInstanceDifficultySelector` and `PlumberInstanceDifficultyAnnouncer`