### PR TITLE
Show correct "Nek'zali" mythic boss achievement

### DIFF
--- a/Modules/ExpansionLandingPage/EncounterData.lua
+++ b/Modules/ExpansionLandingPage/EncounterData.lua
@@ -20,7 +20,7 @@ local EncounterData = {
 	--/dump GetMouseFoci()[1].icon:GetTexture()
 	[2849] = {icon = 3012069, achv = {63683, 63681, 63682}},	--Nymrissa Wavecaller
 
-	[2888] = {icon = 7966621, achv = {61372, 63418}},      --Nek'zali the Soulcoiler
+	[2888] = {icon = 7966621, achv = {63523, 63418}},      --Nek'zali the Soulcoiler
 	[2874] = {icon = 7966620, achv = {63524, 63250}},      --Entombed Sentinels
 	[2882] = {icon = 7966618, achv = {63526, 63397}},      --Vashnik the Malignant
 	[2894] = {icon = 7966622, achv = {63525, 63645}},      --The Lost Explorers


### PR DESCRIPTION
Correct the Mythic Nek'zali the Soulcoiler achievement to its proper ID.