### PR TITLE
A (Slightly) New Approach to Manage Blizzard Frame Modification

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -162,13 +162,16 @@ do  -- String
 	end
 	API.GetUnitIDGeneral = GetUnitIDGeneral;
 
-	local function GetGlobalObject(objNameKey)
+	local function GetGlobalObject(objNameKey, showTrace)
 		--Get object via string "FrameName.Key1.Key2"
 		local obj = _G;
 
 		for k in string.gmatch(objNameKey, "%w+") do
 			obj = obj[k];
 			if not obj then
+				if showTrace then
+					API.PrintMessage(string.format("Failed to find %s (stopped at %s)", objNameKey, k));
+				end
 				return
 			end
 		end

--- a/Initialization.lua
+++ b/Initialization.lua
@@ -20,7 +20,6 @@ local EL = CreateFrame("Frame");
 
 local CallbackRegistry = {};
 CallbackRegistry.events = {};
-CallbackRegistry.addonLoadedCallbacks = {};
 addon.CallbackRegistry = CallbackRegistry;
 
 local tinsert = table.insert;
@@ -117,26 +116,6 @@ do  --CallbackRegistry
 				end
 				cb = callbacks[i];
 			end
-		end
-	end
-
-	function CallbackRegistry:RegisterAddOnLoadedCallback(name, callback)
-		if C_AddOns.IsAddOnLoaded(name) then
-			callback();
-			return
-		end
-
-		if not self.addonLoadedCallbacks[name] then
-			self.addonLoadedCallbacks[name] = {};
-			EL:RegisterEvent("ADDON_LOADED");
-		end
-
-		self.addonLoadedCallbacks[name][callback] = true;
-	end
-
-	function CallbackRegistry:UnregisterAddOnLoadedCallback(name, callback)
-		if self.addonLoadedCallbacks[name] then
-			self.addonLoadedCallbacks[name][callback] = nil;
 		end
 	end
 end
@@ -485,17 +464,8 @@ EL:SetScript("OnEvent", function(self, event, ...)
 	if event == "ADDON_LOADED" then
 		local name = ...
 		if name == addonName then
-			self.plumberLoaded = true;
 			self:UnregisterEvent(event);
 			LoadDatabase();
-		elseif self.plumberLoaded then
-			if CallbackRegistry.addonLoadedCallbacks[name] then
-				local tbl = CallbackRegistry.addonLoadedCallbacks[name];
-				CallbackRegistry.addonLoadedCallbacks[name] = nil;
-				for callback in pairs(tbl) do
-					callback();
-				end
-			end
 		end
 	elseif event == "PLAYER_ENTERING_WORLD" then
 		self:UnregisterEvent(event);

--- a/Modules/CatalystUI.lua
+++ b/Modules/CatalystUI.lua
@@ -84,7 +84,7 @@ end
 
 do	--ItemInteractionFrame
 	local SubModule = {};
-	SubModule.name = "Blizzard_ItemInteractionUI";
+	SubModule.frameName = "ItemInteractionFrame";
 
 	local function GetOutputItemLink()
 		local info = C_TooltipInfo.GetItemInteractionItem();
@@ -162,16 +162,15 @@ end
 
 do
 	local function EnableModule(state)
-		local registry = addon.CallbackRegistry;
 		if state and not MODULE_ENABLED then
 			MODULE_ENABLED = true;
 			for _, subModule in ipairs(SubModules) do
-				registry:RegisterAddOnLoadedCallback(subModule.name, subModule.callback);
+				addon.BlizzardFrameUtil:AddFrameModifier(subModule.frameName, subModule.callback);
 			end
 		elseif (not state) and MODULE_ENABLED then
 			MODULE_ENABLED = false;
 			for _, subModule in ipairs(SubModules) do
-				registry:UnregisterAddOnLoadedCallback(subModule.name, subModule.callback);
+				addon.BlizzardFrameUtil:RemoveFrameModifier(subModule.frameName, subModule.callback);
 			end
 		end
 	end

--- a/Modules/CraftSearchExtended.lua
+++ b/Modules/CraftSearchExtended.lua
@@ -422,7 +422,7 @@ end
 
 
 
-local function Blizzard_Professions_OnLoaded()
+local function Blizzard_Professions_OnLoaded(ProfessionsFrame)
 	if MainFrame then return end;
 
 	CreateUI();
@@ -445,10 +445,10 @@ do  --Module Registry
 	local function EnabledModule(state)
 		MODULE_ENABLED = state;
 		if state then
-			addon.CallbackRegistry:RegisterAddOnLoadedCallback("Blizzard_Professions", Blizzard_Professions_OnLoaded);
+			addon.BlizzardFrameUtil:AddFrameModifier("ProfessionsFrame", Blizzard_Professions_OnLoaded);
 			EventRegistry:RegisterCallback("ProfessionsFrame.Minimized", SearchBox_OnTextChanged, DummyOwner);
 		else
-			addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_Professions", Blizzard_Professions_OnLoaded);
+			addon.BlizzardFrameUtil:RemoveFrameModifier("ProfessionsFrame", Blizzard_Professions_OnLoaded);
 			EventRegistry:UnregisterCallback("ProfessionsFrame.Minimized", DummyOwner);
 			HideUI();
 		end

--- a/Modules/Housing/CatalogSearch.lua
+++ b/Modules/Housing/CatalogSearch.lua
@@ -278,7 +278,7 @@ local function ModifySearcherBase(f, ownedOnly)
 end
 
 
-local function Blizzard_HouseEditor_OnLoad()
+local function Blizzard_HouseEditor_OnLoad(HouseEditorFrame)
 	Housing.DataProvider:Init();
 
 	C_Timer.After(0, function()
@@ -288,7 +288,7 @@ local function Blizzard_HouseEditor_OnLoad()
 end
 
 
-local function Blizzard_HousingDashboard_OnLoad()
+local function Blizzard_HousingDashboard_OnLoad(HousingDashboardFrame)
 	Housing.DataProvider:Init();
 
 	C_Timer.After(0, function()
@@ -298,8 +298,8 @@ end
 
 
 local BlizzardAddOns = {
-	{name = "Blizzard_HousingDashboard", callback = Blizzard_HousingDashboard_OnLoad},
-	{name = "Blizzard_HouseEditor", callback = Blizzard_HouseEditor_OnLoad},
+	{frameName = "HousingDashboardFrame", callback = Blizzard_HousingDashboard_OnLoad},
+	{frameName = "HouseEditorFrame", callback = Blizzard_HouseEditor_OnLoad},
 };
 
 
@@ -338,14 +338,14 @@ do
 	local function EnableModule(state)
 		if state then
 			for _, v in ipairs(BlizzardAddOns) do
-				addon.CallbackRegistry:RegisterAddOnLoadedCallback(v.name, v.callback);
+				addon.BlizzardFrameUtil:AddFrameModifier(v.frameName, v.callback);
 			end
 			ModifyContextMenu();
 			MODULE_ENABLED = true;
 		else
 			MODULE_ENABLED = false;
 			for _, v in ipairs(BlizzardAddOns) do
-				addon.CallbackRegistry:UnregisterAddOnLoadedCallback(v.name, v.callback);
+				addon.BlizzardFrameUtil:RemoveFrameModifier(v.frameName, v.callback);
 			end
 		end
 	end

--- a/Modules/Housing/Housing_Macro.lua
+++ b/Modules/Housing/Housing_Macro.lua
@@ -239,7 +239,7 @@ local function HousingDashboard_OnLoaded(HousingDashboardFrame)
 			blizzardDropdown.playerHouseList = nil;
 		end
 
-		local TeleportButton = API.GetGlobalObject("HousingDashboardFrame.HouseInfoContent.ContentFrame.HouseUpgradeFrame.TeleportToHouseButton");
+		local TeleportButton = HousingDashboardFrame.HouseInfoContent.ContentFrame.HouseUpgradeFrame.TeleportToHouseButton;
 		if TeleportButton then
 			TeleportButton:RegisterForDrag("LeftButton");
 

--- a/Modules/Housing/Housing_Macro.lua
+++ b/Modules/Housing/Housing_Macro.lua
@@ -230,11 +230,11 @@ addon.CallbackRegistry:Register("DBLoaded", function()
 end);
 
 
-local function Blizzard_HousingDashboard_OnLoaded()
+local function HousingDashboard_OnLoaded(HousingDashboardFrame)
 	if not Flags.TeleportToHouseButton then
 		Flags.TeleportToHouseButton = true;
 
-		local blizzardDropdown = API.GetGlobalObject("HousingDashboardFrame.HouseDropdown");
+		local blizzardDropdown = HousingDashboardFrame.HouseDropdown;
 		if blizzardDropdown then
 			blizzardDropdown.playerHouseList = nil;
 		end
@@ -262,6 +262,8 @@ local function Blizzard_HousingDashboard_OnLoaded()
 					tooltip:Show();
 				end
 			end);
+		else
+			API.PrintMessage("TeleportToHouseButton is missing");
 		end
 	end
 end
@@ -272,9 +274,9 @@ local function EnableModule(state)
 	Housing.RequestUpdateHouseInfo();
 	Flags.macroEnabled = state;
 	if state then
-		addon.CallbackRegistry:RegisterAddOnLoadedCallback("Blizzard_HousingDashboard", Blizzard_HousingDashboard_OnLoaded);
+		addon.BlizzardFrameUtil:AddFrameModifier("HousingDashboardFrame", HousingDashboard_OnLoaded);
 	else
-		addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_HousingDashboard", Blizzard_HousingDashboard_OnLoaded);
+		addon.BlizzardFrameUtil:RemoveFrameModifier("HousingDashboardFrame", HousingDashboard_OnLoaded);
 	end
 end
 

--- a/Modules/HuntTable.lua
+++ b/Modules/HuntTable.lua
@@ -130,14 +130,14 @@ end
 --local function Callback_RemoveAllData(dataProvider)
 --end
 
-local function OnBlizzardUILoaded()
+local function OnBlizzardUILoaded(CovenantMissionFrame)
 	if not Def.loaded then
 		Def.loaded = true;
 	else
 		return;
 	end
 
-	local map = addon.API.GetGlobalObject("CovenantMissionFrame.MapTab");
+	local map = CovenantMissionFrame.MapTab;
 	local dataProviders = map and map.dataProviders;
 	local found;
 
@@ -165,10 +165,10 @@ do
 	local function EnableModule(state)
 		if state and not MODULE_ENABLED then
 			MODULE_ENABLED = true;
-			addon.CallbackRegistry:RegisterAddOnLoadedCallback("Blizzard_GarrisonUI", OnBlizzardUILoaded);
+			addon.BlizzardFrameUtil:AddFrameModifier("CovenantMissionFrame", OnBlizzardUILoaded);
 		elseif (not state) and MODULE_ENABLED then
 			MODULE_ENABLED = false;
-			addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_GarrisonUI", OnBlizzardUILoaded);
+			addon.BlizzardFrameUtil:RemoveFrameModifier("CovenantMissionFrame", OnBlizzardUILoaded);
 			RestoreAllPins();
 		end
 	end

--- a/Modules/OutfitSelect.lua
+++ b/Modules/OutfitSelect.lua
@@ -840,13 +840,13 @@ do  --Module Registry
 	local function EnableModule(state)
 		if state and not EL.enabled then
 			EL.enabled = true;
-			addon.CallbackRegistry:RegisterAddOnLoadedCallback("Blizzard_Transmog", Mod.Transmog_OnLoad);
+			addon.BlizzardFrameUtil:AddFrameModifier("TransmogFrame", Mod.Transmog_OnLoad);
 		elseif (not state) and EL.enabled then
 			EL.enabled = nil;
 			if TransmogFrame then
 				Mod.MaximizeTransmogUI();
 			end
-			addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_Transmog", Mod.Transmog_OnLoad);
+			addon.BlizzardFrameUtil:RemoveFrameModifier("TransmogFrame", Mod.Transmog_OnLoad);
 		end
 	end
 

--- a/Modules/Shared/BlizzardFrameUtil.lua
+++ b/Modules/Shared/BlizzardFrameUtil.lua
@@ -1,0 +1,105 @@
+--- For modifying Blizzard frames that are load-on-demand.
+
+
+local _, addon = ...
+
+local BlizzardFrameUtil = CreateFrame("Frame");
+addon.BlizzardFrameUtil = BlizzardFrameUtil;
+
+
+local FrameToAddon = {
+	-- [frameName] = addonName,
+
+	-- HuntTable
+	CovenantMissionFrame = "Blizzard_GarrisonUI",
+
+	-- Housing_Macro, SourceAchievementLink, CatalogSearch(Retired)
+	HousingDashboardFrame = "Blizzard_HousingDashboard",
+
+	-- CatalogSearch(Retired)
+	HouseEditorFrame = "Blizzard_HouseEditor",
+
+	-- CatalystUI, StaticPopup_Confirm
+	ItemInteractionFrame = "Blizzard_ItemInteractionUI",
+
+	-- SourceAchievementLink
+	MountJournal = "Blizzard_Collections",
+
+	-- CraftSearchExtended(Retired)
+	ProfessionsFrame = "Blizzard_Professions",
+
+	-- OutfitSelect, TransmogRestorePending
+	TransmogFrame = "Blizzard_Transmog",
+};
+
+
+local function RunFrameCallback(addonName, frameName, callback)
+	if _G[frameName] then
+		callback(_G[frameName]);
+	else
+		addon.API.PrintMessage(string.format("%s is loaded but %s is missing", addonName, frameName));
+	end
+end
+
+local AddonCallbacks = {};
+
+function BlizzardFrameUtil:OnEvent(event, addonName)
+	if event == "ADDON_LOADED" then
+		if AddonCallbacks[addonName] then
+			for callback, frameName in pairs(AddonCallbacks[addonName]) do
+				RunFrameCallback(addonName, frameName, callback);
+			end
+			AddonCallbacks[addonName] = nil;
+			self:CheckQueue();
+		end
+	end
+end
+
+function BlizzardFrameUtil:CheckQueue()
+	if next(AddonCallbacks) == nil then
+		if self.anyCallback then
+			self.anyCallback = nil;
+			self:UnregisterEvent("ADDON_LOADED");
+		end
+	end
+end
+
+---Process a load-on-demand Blizzard Frame with a function
+---@param frameName string The name of the Blizzard Frame
+---@param modifierFunc function The frame will be sent into this function
+function BlizzardFrameUtil:AddFrameModifier(frameName, modifierFunc)
+	local addonName = FrameToAddon[frameName];
+	if not addonName then return; end
+
+
+	if C_AddOns.IsAddOnLoaded(addonName) then
+		RunFrameCallback(addonName, frameName, modifierFunc);
+	else
+		if not AddonCallbacks[addonName] then
+			AddonCallbacks[addonName] = {};
+		end
+		AddonCallbacks[addonName][modifierFunc] = frameName;
+
+		if not self.anyCallback then
+			self.anyCallback = true;
+			self:RegisterEvent("ADDON_LOADED");
+			self:SetScript("OnEvent", self.OnEvent);
+		end
+	end
+end
+
+---Remove a frame modifierFunc
+---@param frameName string The name of the Blizzard Frame
+---@param modifierFunc function The modifier to be removed
+function BlizzardFrameUtil:RemoveFrameModifier(frameName, modifierFunc)
+	local addonName = FrameToAddon[frameName];
+	if not (addonName and AddonCallbacks[addonName]) then return; end
+
+	AddonCallbacks[addonName][modifierFunc] = nil;
+
+	if next(AddonCallbacks[addonName]) == nil then
+		AddonCallbacks[addonName] = nil;
+	end
+
+	self:CheckQueue();
+end

--- a/Modules/Shared/Load.xml
+++ b/Modules/Shared/Load.xml
@@ -5,6 +5,7 @@
 	<Include file="SharedTooltip.lua"/>
 	<Include file="SharedEditMode.lua"/>
 	<Include file="CooldownUtil.lua"/>
+	<Include file="BlizzardFrameUtil.lua"/>
 	<Include file="BlizzardEditMode.lua"/>
 	<Include file="WidgetSetUtil.lua"/>
 	<Include file="TraitSystem.lua"/>

--- a/Modules/SourceAchievementLink.lua
+++ b/Modules/SourceAchievementLink.lua
@@ -393,7 +393,7 @@ do  --Decor Catalog
 		end
 	end
 
-	function Blizzard_HousingDashboard_OnLoad()
+	function Blizzard_HousingDashboard_OnLoad(HousingDashboardFrame)
 		C_Timer.After(0, function()
 			ModifyTextContainer(HousingDashboardFrame.CatalogContent.PreviewFrame);
 		end);
@@ -402,20 +402,20 @@ end
 
 
 local BlizzardAddOns = {
-	{name = "Blizzard_HousingDashboard", callback = Blizzard_HousingDashboard_OnLoad},
-	{name = "Blizzard_Collections", callback = Blizzard_Collections_OnLoad},
+	{frameName = "HousingDashboardFrame", callback = Blizzard_HousingDashboard_OnLoad},
+	{frameName = "MountJournal", callback = Blizzard_Collections_OnLoad},
 };
 
 do
 	local function EnableModule(state)
 		if state then
 			for _, v in ipairs(BlizzardAddOns) do
-				addon.CallbackRegistry:RegisterAddOnLoadedCallback(v.name, v.callback);
+				addon.BlizzardFrameUtil:AddFrameModifier(v.frameName, v.callback);
 			end
 			MODULE_ENABLED = true;
 		else
 			for _, v in ipairs(BlizzardAddOns) do
-				addon.CallbackRegistry:UnregisterAddOnLoadedCallback(v.name, v.callback);
+				addon.BlizzardFrameUtil:RemoveFrameModifier(v.frameName, v.callback);
 			end
 			MODULE_ENABLED = false;
 		end

--- a/Modules/StaticPopup_Confirm.lua
+++ b/Modules/StaticPopup_Confirm.lua
@@ -72,11 +72,11 @@ local function EnableModule(state)
 	if state and not MODULE_ENABLED then
 		MODULE_ENABLED = true;
 		ModifyDialogs();
-		addon.CallbackRegistry:RegisterAddOnLoadedCallback("Blizzard_ItemInteractionUI", ModifyDialogs);
+		addon.BlizzardFrameUtil:AddFrameModifier("ItemInteractionFrame", ModifyDialogs);
 	elseif (not state) and MODULE_ENABLED then
 		MODULE_ENABLED = false;
 		RestoreDialogs();
-		addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_ItemInteractionUI", ModifyDialogs);
+		addon.BlizzardFrameUtil:RemoveFrameModifier("ItemInteractionFrame", ModifyDialogs);
 	end
 end
 

--- a/Modules/TransmogRestorePending.lua
+++ b/Modules/TransmogRestorePending.lua
@@ -727,7 +727,7 @@ do
 		end
 	end
 
-	function EL.SnapshotFrame_OnLoad()
+	function EL.SnapshotFrame_OnLoad(TransmogFrame)
 		if EL.snapshotHooked then return end;
 		EL.snapshotHooked = true;
 
@@ -753,10 +753,10 @@ do
 		if state and not EL.enabled then
 			EL.enabled = true;
 			EL.LoadPendingFromDB();
-			addon.CallbackRegistry:RegisterAddOnLoadedCallback("Blizzard_Transmog", EL.SnapshotFrame_OnLoad);
+			addon.BlizzardFrameUtil:AddFrameModifier("TransmogFrame", EL.SnapshotFrame_OnLoad);
 		elseif (not state) and EL.enabled then
 			EL.enabled = nil;
-			addon.CallbackRegistry:UnregisterAddOnLoadedCallback("Blizzard_Transmog", EL.SnapshotFrame_OnLoad);
+			addon.BlizzardFrameUtil:RemoveFrameModifier("TransmogFrame", EL.SnapshotFrame_OnLoad);
 			EL.WipePendingAppearanceFromDB(true, true);
 			addon.SetDBValue(DBKEY_ALWAYS_MOVE_CHANGED, false);
 		end


### PR DESCRIPTION
- So we can use the frame name instead of the Blizzard addon name.
- Having a single file to tell which module modifies which Blizzard frame.